### PR TITLE
feat(cli): implement basic curl functionality

### DIFF
--- a/internal/cli/README.txt
+++ b/internal/cli/README.txt
@@ -6,6 +6,17 @@ to facilitate network epxloration and measurements.
 
 We support these commands:
 
+    curl    Emulates a subset of the `curl(1)` command.
     dig     Emulates a subset of the `dig(1)` command.
+
+You can combine these two commands as follows:
+
+    $ rbmk dig +short example.com
+    93.184.215.14
+
+    $ rbmk curl --resolve example.com:443:93.184.215.14 https://example.com/
+    <!doctype html>
+    <html>
+    [... rest of the response body ...]
 
 Run `rbmk COMMAND --help` for more information about `COMMAND`.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 
 	"github.com/rbmk-project/common/cliutils"
+	"github.com/rbmk-project/rbmk/internal/cli/curl"
 	"github.com/rbmk-project/rbmk/internal/cli/dig"
 )
 
@@ -16,6 +17,7 @@ var readme string
 // NewCommand constructs a new [cliutils.Command] for the `rbmk` command.
 func NewCommand() cliutils.Command {
 	return cliutils.NewCommandWithSubCommands("rbmk", readme, map[string]cliutils.Command{
-		"dig": dig.NewCommand(),
+		"curl": curl.NewCommand(),
+		"dig":  dig.NewCommand(),
 	})
 }

--- a/internal/cli/curl/README.txt
+++ b/internal/cli/curl/README.txt
@@ -1,0 +1,54 @@
+usage: rbmk curl [-flags] URL
+
+A subset of curl(1) functionality focused on network measurements. We only
+support measuring `http://` and `https://` URLs.
+
+We currently support the following command line flags:
+
+    -h, --help
+        Print this help message.
+
+    --logs FILE
+        Writes structured logs to the given FILE. If FILE already exists, we
+        append to it. If FILE does not exist, we create it. If FILE is a single
+        dash (`-`), we write to the stdout. If you specify `--logs` multiple
+        times, we write to the last FILE specified.
+
+    -o, --output FILE
+        Write the response body to FILE instead of using the stdout.
+
+    --resolve HOST:PORT:ADDR
+        Use ADDR instead of DNS resolution for HOST:PORT.
+
+        Implementation note: we ignore the port and replace the HOST with
+        ADDR for every port number. Additionally, when using this flag, the
+        DNS lookup fails with "no such host" if the URL host is not HOST.
+
+    -v, --verbose
+        Make the operation more talkative.
+
+    -X, --request METHOD
+        Use the given request METHOD instead of GET.
+
+For example, the following invocation prints the response body
+of the `https://example.com/` website URL:
+
+    $ rbmk curl https://example.com/
+
+To also print request and response headers, use `-v`:
+
+    $ rbmk curl -v https://example.com/
+
+To save structured logs to `logfile.jsonl` use `--logs`:
+
+    $ rbmk curl --logs logfile.jsonl https://example.com/
+
+To save the response body to a `output.txt` use `-o`:
+
+    $ rbmk curl -o output.txt https://example.com/
+
+To use a previously resolved IP address, use `--resolve`:
+
+    $ rbmk curl --resolve example.com:443:93.184.215.14 https://example.com/
+
+This command exits with `0` on success and `1` on failure.

--- a/internal/cli/curl/curl.go
+++ b/internal/cli/curl/curl.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package curl implements the `rbmk curl` command.
+package curl
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/rbmk-project/common/cliutils"
+	"github.com/rbmk-project/rbmk/internal/testable"
+	"github.com/spf13/pflag"
+)
+
+// NewCommand creates the `rbmk curl` Command.
+func NewCommand() cliutils.Command {
+	return command{}
+}
+
+type command struct{}
+
+//go:embed README.txt
+var readme string
+
+// Help implements cliutils.Command.
+func (cmd command) Help(argv ...string) error {
+	fmt.Fprintf(os.Stdout, "%s\n", readme)
+	return nil
+}
+
+// Main implements cliutils.Command.
+func (cmd command) Main(ctx context.Context, argv ...string) error {
+	// 1. honour requests for printing the help
+	if cliutils.HelpRequested(argv...) {
+		return cmd.Help(argv...)
+	}
+
+	testableStdout := testable.Stdout.Get()
+
+	// 2. create initial task with defaults
+	task := &Task{
+		LogsWriter:    io.Discard,
+		Method:        "GET",
+		Output:        os.Stdout,
+		ResolveMap:    make(map[string]string),
+		URL:           "",
+		VerboseOutput: io.Discard,
+	}
+
+	// 3. create command line parser
+	clip := pflag.NewFlagSet("rbmk curl", pflag.ContinueOnError)
+
+	// 4. add flags to the parser
+	logfile := clip.String("logs", "", "path where to write structured logs")
+	output := clip.StringP("output", "o", "", "write to file instead of stdout")
+	method := clip.StringP("request", "X", "GET", "HTTP request method")
+	resolve := clip.StringArray("resolve", nil, "use addr instead of DNS")
+	verbose := clip.BoolP("verbose", "v", false, "make more talkative")
+
+	// 5. parse command line arguments
+	if err := clip.Parse(argv[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Run `rbmk curl --help` for usage.\n")
+		return err
+	}
+
+	// 6. make sure we have exactly one URL argument
+	positional := clip.Args()
+	if len(positional) != 1 {
+		err := errors.New("expected exactly one URL argument")
+		fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Run `rbmk curl --help` for usage.\n")
+		return err
+	}
+
+	// 7. process the URL argument
+	task.URL = positional[0]
+	if !strings.HasPrefix(task.URL, "http://") && !strings.HasPrefix(task.URL, "https://") {
+		err := errors.New("URL scheme must be http:// or https://")
+		fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Run `rbmk curl --help` for usage.\n")
+		return err
+	}
+
+	// 8. process --resolve entries by splitting
+	for _, entry := range *resolve {
+		parts := strings.SplitN(entry, ":", 3)
+		if len(parts) != 3 {
+			err := fmt.Errorf("invalid --resolve value: %s", entry)
+			fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
+			fmt.Fprintf(os.Stderr, "Run `rbmk curl --help` for usage.\n")
+			return err
+		}
+		// Implementation note: we ignore the port since our
+		// LookupHost function does not know the port.
+		task.ResolveMap[parts[0]] = parts[2]
+	}
+
+	// 9. process other flags
+	task.Method = *method
+	if *verbose {
+		task.VerboseOutput = os.Stderr
+	}
+
+	// 10. handle --logs flag
+	switch *logfile {
+	case "":
+		// nothing
+	case "-":
+		task.LogsWriter = testableStdout
+	default:
+		filep, err := os.OpenFile(*logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+		if err != nil {
+			err = fmt.Errorf("cannot open log file: %w", err)
+			fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
+			return err
+		}
+		defer filep.Close()
+		task.LogsWriter = io.MultiWriter(task.LogsWriter, filep)
+	}
+
+	// 11. handle -o/--output flag
+	if *output != "" {
+		filep, err := os.OpenFile(*output, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if err != nil {
+			err = fmt.Errorf("cannot create output file: %w", err)
+			fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
+			return err
+		}
+		defer filep.Close()
+		task.Output = filep
+	}
+
+	// 12. run the task
+	if err := task.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/internal/cli/curl/httplog.go
+++ b/internal/cli/curl/httplog.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package curl
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/rbmk-project/x/errclass"
+)
+
+// TODO(bassosimone): we should probably share this
+// functionality with the `dig` task as well.
+
+// httpLogTransport is an http.RoundTripper that logs.
+type httpLogTransport struct {
+	// Logger is the optional Logger to use.
+	Logger *slog.Logger
+
+	// RoundTripper is the mandatory http.RoundTripper to use.
+	RoundTripper http.RoundTripper
+
+	// TimeNow is the optional time function to use.
+	TimeNow func() time.Time
+}
+
+// RoundTrip implements [http.RoundTripper].
+func (txp *httpLogTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// TODO(bassosimone): adapt support for obtaining the
+	// connection information from the dnscore package
+
+	// possibly emit a structured log event before the round trip
+	t0 := txp.timeNow()
+	if txp.Logger != nil {
+		txp.Logger.InfoContext(
+			req.Context(),
+			"httpRoundTripStart",
+			slog.String("httpMethod", req.Method),
+			slog.String("httpUrl", req.URL.String()),
+			slog.Any("httpRequestHeaders", req.Header),
+			slog.Time("t", t0),
+		)
+	}
+
+	// perform the actual round trip
+	resp, err := txp.RoundTripper.RoundTrip(req)
+	t := txp.timeNow()
+
+	// handle the case of failure
+	if err != nil {
+		if txp.Logger != nil {
+			txp.Logger.InfoContext(
+				req.Context(),
+				"httpRoundTripDone",
+				slog.String("errClass", errclass.New(err)),
+				slog.Any("err", err),
+				slog.String("httpMethod", req.Method),
+				slog.String("httpUrl", req.URL.String()),
+				slog.Any("httpRequestHeaders", req.Header),
+				slog.Time("t0", t0),
+				slog.Time("t", t),
+			)
+		}
+		return nil, err
+	}
+
+	// handle the case of success
+	txp.Logger.InfoContext(
+		req.Context(),
+		"httpRoundTripDone",
+		slog.String("httpMethod", req.Method),
+		slog.String("httpUrl", req.URL.String()),
+		slog.Any("httpRequestHeaders", req.Header),
+		slog.Int("httpResponseStatusCode", resp.StatusCode),
+		slog.Any("httpResponseHeaders", resp.Header),
+		slog.Time("t0", t0),
+		slog.Time("t", t),
+	)
+	return resp, nil
+}
+
+// timeNow returns the current time.
+func (txp *httpLogTransport) timeNow() time.Time {
+	if txp.TimeNow != nil {
+		return txp.TimeNow()
+	}
+	return time.Now()
+}

--- a/internal/cli/curl/task.go
+++ b/internal/cli/curl/task.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package curl
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+
+	"github.com/rbmk-project/dnscore"
+	"github.com/rbmk-project/rbmk/internal/testable"
+	"github.com/rbmk-project/x/closepool"
+	"github.com/rbmk-project/x/netcore"
+)
+
+// Task runs the curl task.
+type Task struct {
+	// LogsWriter is where we write structured logs
+	LogsWriter io.Writer
+
+	// Method is the HTTP method to use
+	Method string
+
+	// Output is where we write the response body
+	Output io.Writer
+
+	// ResolveMap maps HOST:PORT to IP address
+	ResolveMap map[string]string
+
+	// URL is the URL to fetch
+	URL string
+
+	// VerboseOutput is where we write the verbose output
+	VerboseOutput io.Writer
+}
+
+// Run executes the curl task
+func (task *Task) Run(ctx context.Context) error {
+	// Set up the JSON logger for writing the measurements
+	logger := slog.New(slog.NewJSONHandler(task.LogsWriter, &slog.HandlerOptions{}))
+
+	// Create a pool containing closers
+	pool := &closepool.Pool{}
+	defer pool.Close()
+
+	// Create netcore network instance
+	netx := &netcore.Network{}
+	netx.DialContextFunc = testable.DialContext.Get()
+	netx.RootCAs = testable.RootCAs.Get()
+	netx.Logger = logger
+	netx.WrapConn = func(ctx context.Context, netx *netcore.Network, conn net.Conn) net.Conn {
+		conn = netcore.WrapConn(ctx, netx, conn)
+		pool.Add(conn)
+		return conn
+	}
+
+	// Honour the `--resolve` command line flag
+	netx.LookupHostFunc = func(ctx context.Context, domain string) ([]string, error) {
+		if resolved, ok := task.ResolveMap[domain]; ok {
+			return []string{resolved}, nil
+		}
+		return nil, dnscore.ErrNoName
+	}
+
+	// Create the HTTP client to use
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Transport: &httpLogTransport{
+			Logger: logger,
+			RoundTripper: &http.Transport{
+				DialContext:       netx.DialContext,
+				DialTLSContext:    netx.DialTLSContext,
+				ForceAttemptHTTP2: true,
+			},
+		},
+	}
+
+	// Create the HTTP request
+	req, err := http.NewRequestWithContext(ctx, task.Method, task.URL, nil)
+	if err != nil {
+		return fmt.Errorf("cannot create request: %w", err)
+	}
+
+	// Print the request, if verbose
+	fmt.Fprintf(task.VerboseOutput, "> %s %s HTTP/%d.%d\n",
+		req.Method, req.URL.RequestURI(),
+		req.ProtoMajor, req.ProtoMinor)
+	task.printHeaders(req.Header, ">")
+	fmt.Fprintf(task.VerboseOutput, "\n")
+
+	// Perform the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Print the response, if verbose
+	fmt.Fprintf(task.VerboseOutput, "< HTTP/%d.%d %d %s\n",
+		resp.ProtoMajor, resp.ProtoMinor,
+		resp.StatusCode, resp.Status)
+	task.printHeaders(resp.Header, "<")
+	fmt.Fprintf(task.VerboseOutput, "\n")
+
+	// Copy the response body
+	if _, err := io.Copy(task.Output, resp.Body); err != nil {
+		return fmt.Errorf("reading or writing response body: %w", err)
+	}
+	return nil
+}
+
+// printHeaders prints HTTP headers with the given prefix
+func (task *Task) printHeaders(headers http.Header, prefix string) {
+	for name, values := range headers {
+		for _, value := range values {
+			fmt.Fprintf(task.VerboseOutput, "%s %s: %s\n", prefix, name, value)
+		}
+	}
+}


### PR DESCRIPTION
Our first milestone is to provide basic dig and curl functionality to perform network measurements. The curl functionality is probably still a bit too basic, but this is a starting point.

We will test it for a while, find bugs, and squash them.