### PR TITLE
fix(i/c/README.txt): correct typo

### DIFF
--- a/internal/cli/README.txt
+++ b/internal/cli/README.txt
@@ -2,7 +2,7 @@
 usage: rbmk COMMAND [args...]
 
 RBMK (Really Basic Measurement Kit) is a command-line utility
-to facilitate network epxloration and measurements.
+to facilitate network exploration and measurements.
 
 We support these commands:
 


### PR DESCRIPTION
This diff corrects a typo in the `rbmk` help output.