### PR TITLE
fix(dig curl): enforce max operation runtime

### DIFF
--- a/internal/cli/curl/README.txt
+++ b/internal/cli/curl/README.txt
@@ -14,6 +14,11 @@ We currently support the following command line flags:
         dash (`-`), we write to the stdout. If you specify `--logs` multiple
         times, we write to the last FILE specified.
 
+    --max-time DURATION
+        Sets the maximum time that the transfer operation is allowed to take
+        in seconds (e.g., `--max-time 5`). If this flag is not specified, the
+        default max time is 30 seconds.
+
     -o, --output FILE
         Write the response body to FILE instead of using the stdout.
 

--- a/internal/cli/curl/curl.go
+++ b/internal/cli/curl/curl.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/rbmk-project/common/cliutils"
 	"github.com/rbmk-project/rbmk/internal/testable"
@@ -53,6 +54,7 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	// 2. create initial task with defaults
 	task := &Task{
 		LogsWriter:    io.Discard,
+		MaxTime:       30 * time.Second,
 		Method:        "GET",
 		Output:        os.Stdout,
 		ResolveMap:    make(map[string]string),
@@ -65,6 +67,7 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 
 	// 4. add flags to the parser
 	logfile := clip.String("logs", "", "path where to write structured logs")
+	maxTime := clip.Int64("max-time", 30, "maximum time to wait for the operation to finish")
 	output := clip.StringP("output", "o", "", "write to file instead of stdout")
 	method := clip.StringP("request", "X", "GET", "HTTP request method")
 	resolve := clip.StringArray("resolve", nil, "use addr instead of DNS")
@@ -110,6 +113,7 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	}
 
 	// 9. process other flags
+	task.MaxTime = time.Duration(*maxTime) * time.Second
 	task.Method = *method
 	if *verbose {
 		task.VerboseOutput = os.Stderr

--- a/internal/cli/dig/README.txt
+++ b/internal/cli/dig/README.txt
@@ -35,6 +35,8 @@ a query for the `A` record type. We support these record types:
 
 If you specify `TYPE` multiple times, we emit a warning and use the last one.
 
+Note that, by default, the query will timeout after five seconds.
+
 We currently support the following command line flags:
 
     -h, --help

--- a/internal/cli/dig/task.go
+++ b/internal/cli/dig/task.go
@@ -107,7 +107,8 @@ func (task *Task) newServerAddr(protocol dnscore.Protocol) string {
 // Run runs the task and returns an error.
 func (task *Task) Run(ctx context.Context) error {
 	// Setup the overal operation timeout using the context
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	const timeout = 5 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	// Set up the JSON logger for writing the measurements
@@ -133,6 +134,7 @@ func (task *Task) Run(ctx context.Context) error {
 	transport.DialContext = netx.DialContext
 	transport.DialTLSContext = netx.DialTLSContext
 	transport.HTTPClient = &http.Client{
+		Timeout: timeout, // ensure the overall operation is bounded
 		Transport: &http.Transport{
 			DialContext:       netx.DialContext,
 			DialTLSContext:    netx.DialTLSContext,


### PR DESCRIPTION
Use five seconds for dig without making it configurable. For now, this default should be good enough. For DNS-over-HTTPS, ensure that the timeout also applies to reading the body by setting client.Timeout.

For curl, implement the `--max-time` flag, default it to 30s, and ensure it also applied to reading the body using client.Timeout.

Also, ensure we update the documentation accordingly.