### PR TITLE
fix(dig): improve composability with curl

### DIFF
--- a/pkg/cli/dig/README.txt
+++ b/pkg/cli/dig/README.txt
@@ -72,6 +72,9 @@ We currently support the following query options:
     +short
         Print a short response rather than the full response.
 
+    +short=ip
+        Like `+short`, but only prints the IP address.
+
     +tcp
         Uses DNS-over-TCP. The @server argument is the hostname or IP
         address to use. The implied port is `53/tcp`.

--- a/pkg/cli/dig/README.txt
+++ b/pkg/cli/dig/README.txt
@@ -73,7 +73,7 @@ We currently support the following query options:
         Print a short response rather than the full response.
 
     +short=ip
-        Like `+short`, but only prints the IP address.
+        Like `+short`, but only prints the IP addresses.
 
     +tcp
         Uses DNS-over-TCP. The @server argument is the hostname or IP

--- a/pkg/cli/dig/dig.go
+++ b/pkg/cli/dig/dig.go
@@ -130,9 +130,10 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 				task.QueryWriter = os.Stdout
 				continue
 
-			case arg == "+short":
+			case arg == "+short" || arg == "+short=ip":
 				task.ResponseWriter = io.Discard
 				task.ShortWriter = os.Stdout
+				task.ShortIP = arg == "+short=ip"
 				continue
 
 			case arg == "+tcp":

--- a/pkg/cli/dig/task.go
+++ b/pkg/cli/dig/task.go
@@ -50,6 +50,10 @@ type Task struct {
 	// write the full response when we received it.
 	ResponseWriter io.Writer
 
+	// ShortIP is a flag that ensures that `+short=ip` only
+	// prints the IP addresses in the response.
+	ShortIP bool
+
 	// ShortWriter is the MANDATORY [io.Writer] where we should
 	// write the short response when we received it.
 	ShortWriter io.Writer
@@ -209,19 +213,27 @@ func (task *Task) formatShort(response *dns.Msg) string {
 			fmt.Fprintf(&builder, "%s\n", ans.AAAA.String())
 
 		case *dns.CNAME:
-			fmt.Fprintf(&builder, "%s\n", ans.Target)
+			if !task.ShortIP {
+				fmt.Fprintf(&builder, "%s\n", ans.Target)
+			}
 
 		case *dns.HTTPS:
-			value := strings.TrimPrefix(ans.String(), ans.Hdr.String())
-			fmt.Fprintf(&builder, "%s\n", value)
+			if !task.ShortIP {
+				value := strings.TrimPrefix(ans.String(), ans.Hdr.String())
+				fmt.Fprintf(&builder, "%s\n", value)
+			}
 
 		case *dns.MX:
-			value := strings.TrimPrefix(ans.String(), ans.Hdr.String())
-			fmt.Fprintf(&builder, "%s\n", value)
+			if !task.ShortIP {
+				value := strings.TrimPrefix(ans.String(), ans.Hdr.String())
+				fmt.Fprintf(&builder, "%s\n", value)
+			}
 
 		case *dns.NS:
-			value := strings.TrimPrefix(ans.String(), ans.Hdr.String())
-			fmt.Fprintf(&builder, "%s\n", value)
+			if !task.ShortIP {
+				value := strings.TrimPrefix(ans.String(), ans.Hdr.String())
+				fmt.Fprintf(&builder, "%s\n", value)
+			}
 
 		default:
 			// TODO(bassosimone): implement the other answer types

--- a/pkg/cli/intro/README.txt
+++ b/pkg/cli/intro/README.txt
@@ -8,7 +8,7 @@ these to perform step-by-step measurements.
 Basic Examples:
 
 1. DNS resolution only:
-    $ rbmk dig +short example.com
+    $ rbmk dig +short=ip example.com
     93.184.215.14
 
 2. HTTP fetch:
@@ -18,7 +18,7 @@ Basic Examples:
     $ rbmk curl --resolve example.com:443:93.184.215.14 https://example.com/
 
 4. Combining commands to measure DNS and HTTP separately:
-    $ IP=$(rbmk dig +short example.com|head -n1)
+    $ IP=$(rbmk dig +short=ip example.com|head -n1)
     $ rbmk curl --resolve example.com:443:$IP https://example.com/
 
 5. Collecting measurement data:


### PR DESCRIPTION
Implement the `+short=ip` flag to ensure we only print IP addresses, to avoid CNAME popping up and preventing us from implementing proper step-by-step measurements where we choose which specific HTTP endpoint to measure in isolation.