### PR TITLE
doc: update to mention scripting support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,4 +1,7 @@
 # RBMK Design Documents
 
 The [dd-005-rbmk.md](https://github.com/rbmk-project/rbmk-project.github.io/blob/main/docs/design/dd-005-rbmk.md)
-document describes the design of this repository.
+document describes the basic design of the `rbmk` tool.
+
+The [dd-006-rbmk-scripting.md](https://github.com/rbmk-project/rbmk-project.github.io/blob/main/docs/design/dd-006-rbmk-scripting.md)
+document describes `rbmk` scripting extensions.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ you can observe each operation in isolation.
 - Support for multiple DNS protocols (UDP, TCP, DoT, DoH)
 - HTTP(S) measurements with granular control
 
+- Core Measurement Commands:
+  - `dig`: DNS measurements with multiple protocols
+  - `curl`: HTTP(S) endpoint measurements
+
+- Scripting Support:
+  - Built-in POSIX shell interpreter
+  - Cross-platform Unix-like commands
+  - Script generation tools
+  - Consistent workspace organization
+
 The tool is designed to support both general use and measurement-specific
 features, with careful consideration of concurrent operations and
 extensive testing capabilities.
@@ -53,10 +63,22 @@ $ rbmk intro
 
 ## Commands
 
-- `dig`: Performs DNS measurements with a `dig(1)`-like interface
-- `curl`: Measures HTTP/HTTPS endpoints using a `curl(1)`-like interface
-- `intro`: Shows a brief introduction with usage examples
-- `tutorial`: Provides comprehensive usage documentation
+Core Measurement Commands:
+- `curl`: Measures HTTP/HTTPS endpoints with `curl(1)`-like syntax.
+- `dig`: Performs DNS measurements with `dig(1)`-like syntax.
+
+Unix-like Commands for Scripting:
+- `cat`: Concatenates files.
+- `ipuniq`: Filter out duplicate IP addresses.
+- `mkdir`: Creates directories.
+- `rm`: Removes files and directories.
+- `sh`: Runs POSIX shell scripts.
+- `tar`: Creates tar archives.
+- `timestamp`: Prints filesystem-friendly timestamps.
+
+Helper Commands:
+- `intro`: Shows a brief introduction with usage examples.
+- `tutorial`: Provides comprehensive usage documentation.
 
 Each command supports the `--help` flag for detailed usage information.
 

--- a/pkg/cli/README.txt
+++ b/pkg/cli/README.txt
@@ -4,19 +4,22 @@ usage: rbmk COMMAND [args...]
 RBMK (Really Basic Measurement Kit) is a command-line utility
 to facilitate network exploration and measurements.
 
-We support these commands:
+Core measurement commands:
+    curl      Measures HTTP/HTTPS endpoints with `curl(1)`-like syntax.
+    dig       Performs DNS measurements with `dig(1)`-like syntax.
 
+Unix-like commands for scripting:
     cat       Concatenates files to standard output.
-    curl      Emulates a subset of the `curl(1)` command.
-    dig       Emulates a subset of the `dig(1)` command.
-    intro     Shows a brief introduction with usage examples.
-    ipuniq    Sorts unique IP addresses.
+    ipuniq    Filters out duplicate IP addresses.
     mkdir     Creates directories.
     rm        Removes files and directories.
-    sh        Runs shell scripts.
+    sh        Runs POSIX shell scripts.
     tar       Creates tar archives.
     timestamp Prints filesystem-friendly UTC timestamp.
-    tutorial  Shows a more comprehensive guide.
+
+Helper commands:
+    intro     Shows a brief introduction with usage examples.
+    tutorial  Provides comprehensive usage documentation.
 
 New to RBMK? Try `rbmk intro` to get started!
 


### PR DESCRIPTION
This diff modifies DESIGN.md, README.md and the `rbmk --help` output to group commands and mention scripting support.