### PR TITLE
refactor: update to rbmk-project/common/clitools@v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.3
 
 require (
 	github.com/miekg/dns v1.1.62
-	github.com/rbmk-project/common v0.9.0
+	github.com/rbmk-project/common v0.10.0
 	github.com/rbmk-project/dnscore v0.8.0
 	github.com/rbmk-project/x v0.0.0-20241130105031-0e28dad87694
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rbmk-project/common v0.9.0 h1:pbGTkGRBmFE065yM5hBLsEOY68L+DJVGGkeEUCc+lCU=
-github.com/rbmk-project/common v0.9.0/go.mod h1:BsIum8cGFuNxktk3yWVGlr2B18wtyzn3evb3nhvGyig=
+github.com/rbmk-project/common v0.10.0 h1:yac4Yt9/1p1eoMo/8dk0TJxmQ5XgnJfC7Qbx5gAbdqU=
+github.com/rbmk-project/common v0.10.0/go.mod h1:BsIum8cGFuNxktk3yWVGlr2B18wtyzn3evb3nhvGyig=
 github.com/rbmk-project/dnscore v0.8.0 h1:P5qyH1ZSwafdp4b2zbts2DwwuxZvj2BtnwOe9XhJ0bg=
 github.com/rbmk-project/dnscore v0.8.0/go.mod h1:m56W6xysS/Fru7v/6XaSEc6TNZxKxSO6YmnMIIeCP04=
 github.com/rbmk-project/x v0.0.0-20241130105031-0e28dad87694 h1:DvT/Ln2v6qBIW9zVpwhzXldEi+RcRT8qUZCyr3GWZwc=

--- a/internal/qa/registry.go
+++ b/internal/qa/registry.go
@@ -13,7 +13,7 @@ var Registry = []ScenarioDescriptor{
 		Name:    "dnsOverUdpSuccess",
 		Editors: []ScenarioEditor{},
 		Argv: []string{
-			"rbmk", "dig", "+logs", "@8.8.8.8", "A", "www.example.com",
+			"rbmk", "dig", "+noall", "+logs", "@8.8.8.8", "A", "www.example.com",
 		},
 		ExpectedErr: nil,
 		ExpectedSeq: []ExpectedEvent{
@@ -32,7 +32,7 @@ var Registry = []ScenarioDescriptor{
 			CensorDNSLikeIran("www.example.com"),
 		},
 		Argv: []string{
-			"rbmk", "dig", "+logs", "@8.8.8.8", "A", "www.example.com",
+			"rbmk", "dig", "+noall", "+logs", "@8.8.8.8", "A", "www.example.com",
 		},
 		ExpectedErr: nil,
 		ExpectedSeq: []ExpectedEvent{
@@ -53,7 +53,7 @@ var Registry = []ScenarioDescriptor{
 		Name:    "dnsOverTcpSuccess",
 		Editors: []ScenarioEditor{},
 		Argv: []string{
-			"rbmk", "dig", "+logs", "+tcp", "@8.8.8.8", "A", "www.example.com",
+			"rbmk", "dig", "+noall", "+logs", "+tcp", "@8.8.8.8", "A", "www.example.com",
 		},
 		ExpectedErr: nil,
 		ExpectedSeq: []ExpectedEvent{
@@ -74,7 +74,7 @@ var Registry = []ScenarioDescriptor{
 		Name:    "dnsOverTlsSuccess",
 		Editors: []ScenarioEditor{},
 		Argv: []string{
-			"rbmk", "dig", "+logs", "+tls", "@8.8.8.8", "A", "www.example.com",
+			"rbmk", "dig", "+noall", "+logs", "+tls", "@8.8.8.8", "A", "www.example.com",
 		},
 		ExpectedErr: nil,
 		ExpectedSeq: []ExpectedEvent{
@@ -99,7 +99,7 @@ var Registry = []ScenarioDescriptor{
 		Name:    "dnsOverHttpsSuccess",
 		Editors: []ScenarioEditor{},
 		Argv: []string{
-			"rbmk", "dig", "+logs", "+https", "@8.8.8.8", "A", "www.example.com",
+			"rbmk", "dig", "+noall", "+logs", "+https", "@8.8.8.8", "A", "www.example.com",
 		},
 		ExpectedErr: nil,
 		ExpectedSeq: []ExpectedEvent{

--- a/internal/qa/scenario.go
+++ b/internal/qa/scenario.go
@@ -93,11 +93,9 @@ func (desc *ScenarioDescriptor) Run(t Driver) io.Reader {
 	//
 	// Note that `nil` restores `os.Stdout` as the default.
 	rpipe, wpipe := io.Pipe()
-	testable.Stdout.Set(wpipe)
-	defer func() {
-		testable.Stdout.Set(nil)
-		wpipe.Close()
-	}()
+	env := testable.NewEnvironment()
+	env.SetStdout(wpipe)
+	defer wpipe.Close()
 
 	// Buffer to collect all logs and channel to
 	// signal when collection is complete
@@ -112,7 +110,7 @@ func (desc *ScenarioDescriptor) Run(t Driver) io.Reader {
 	cmd := cli.NewCommand()
 
 	// Execute the given argv.
-	err := cmd.Main(context.Background(), desc.Argv...)
+	err := cmd.Main(context.Background(), env, desc.Argv...)
 
 	// Check whether the return value is OK.
 	if desc.ExpectedErr != nil {

--- a/pkg/cli/cat/cat.go
+++ b/pkg/cli/cat/cat.go
@@ -24,41 +24,41 @@ func NewCommand() cliutils.Command {
 
 type command struct{}
 
-func (cmd command) Help(argv ...string) error {
-	fmt.Fprintf(os.Stdout, "%s\n", readme)
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", readme)
 	return nil
 }
 
-func (cmd command) Main(ctx context.Context, argv ...string) error {
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	// 1. honour requests for printing the help
 	if cliutils.HelpRequested(argv...) {
-		return cmd.Help(argv...)
+		return cmd.Help(env, argv...)
 	}
 
 	// 2. ensure we have at least one file to read
 	if len(argv) < 2 {
 		err := errors.New("expected one or more files to concatenate")
-		fmt.Fprintf(os.Stderr, "rbmk cat: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Run `rbmk cat --help` for usage.\n")
+		fmt.Fprintf(env.Stderr(), "rbmk cat: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk cat --help` for usage.\n")
 		return err
 	}
 
 	// 3. concatenate each file to stdout
 	for _, path := range argv[1:] {
-		if err := catFile(path); err != nil {
-			fmt.Fprintf(os.Stderr, "rbmk cat: %s\n", err.Error())
+		if err := catFile(env, path); err != nil {
+			fmt.Fprintf(env.Stderr(), "rbmk cat: %s\n", err.Error())
 			return err
 		}
 	}
 	return nil
 }
 
-func catFile(path string) error {
+func catFile(env cliutils.Environment, path string) error {
 	filep, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer filep.Close()
-	_, err = io.Copy(os.Stdout, filep)
+	_, err = io.Copy(env.Stdout(), filep)
 	return err
 }

--- a/pkg/cli/curl/curl.go
+++ b/pkg/cli/curl/curl.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/rbmk-project/common/cliutils"
-	"github.com/rbmk-project/rbmk/internal/testable"
 	"github.com/spf13/pflag"
 )
 
@@ -29,34 +28,24 @@ type command struct{}
 var readme string
 
 // Help implements cliutils.Command.
-func (cmd command) Help(argv ...string) error {
-	fmt.Fprintf(os.Stdout, "%s\n", readme)
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", readme)
 	return nil
 }
 
 // Main implements cliutils.Command.
-func (cmd command) Main(ctx context.Context, argv ...string) error {
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	// 1. honour requests for printing the help
 	if cliutils.HelpRequested(argv...) {
-		return cmd.Help(argv...)
+		return cmd.Help(env, argv...)
 	}
-
-	// Implementation note: we care about testing whether we
-	// produce the correct logs in several simulated conditions,
-	// therefore, the `stdout` used by logs is overridable
-	// through the `testable` package.
-	//
-	// On the contrary, we care much less about testing logging
-	// the request and response, or other error and output messages,
-	// so we just use `os.Stdout` and `os.Stderr` directly.
-	testableStdout := testable.Stdout.Get()
 
 	// 2. create initial task with defaults
 	task := &Task{
 		LogsWriter:    io.Discard,
 		MaxTime:       30 * time.Second,
 		Method:        "GET",
-		Output:        os.Stdout,
+		Output:        env.Stdout(),
 		ResolveMap:    make(map[string]string),
 		URL:           "",
 		VerboseOutput: io.Discard,
@@ -75,8 +64,8 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 
 	// 5. parse command line arguments
 	if err := clip.Parse(argv[1:]); err != nil {
-		fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Run `rbmk curl --help` for usage.\n")
+		fmt.Fprintf(env.Stderr(), "rbmk curl: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk curl --help` for usage.\n")
 		return err
 	}
 
@@ -84,8 +73,8 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	positional := clip.Args()
 	if len(positional) != 1 {
 		err := errors.New("expected exactly one URL argument")
-		fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Run `rbmk curl --help` for usage.\n")
+		fmt.Fprintf(env.Stderr(), "rbmk curl: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk curl --help` for usage.\n")
 		return err
 	}
 
@@ -93,8 +82,8 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	task.URL = positional[0]
 	if !strings.HasPrefix(task.URL, "http://") && !strings.HasPrefix(task.URL, "https://") {
 		err := errors.New("URL scheme must be http:// or https://")
-		fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Run `rbmk curl --help` for usage.\n")
+		fmt.Fprintf(env.Stderr(), "rbmk curl: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk curl --help` for usage.\n")
 		return err
 	}
 
@@ -103,8 +92,8 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 		parts := strings.SplitN(entry, ":", 3)
 		if len(parts) != 3 {
 			err := fmt.Errorf("invalid --resolve value: %s", entry)
-			fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
-			fmt.Fprintf(os.Stderr, "Run `rbmk curl --help` for usage.\n")
+			fmt.Fprintf(env.Stderr(), "rbmk curl: %s\n", err.Error())
+			fmt.Fprintf(env.Stderr(), "Run `rbmk curl --help` for usage.\n")
 			return err
 		}
 		// Implementation note: we ignore the port since our
@@ -116,7 +105,7 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	task.MaxTime = time.Duration(*maxTime) * time.Second
 	task.Method = *method
 	if *verbose {
-		task.VerboseOutput = os.Stderr
+		task.VerboseOutput = env.Stderr()
 	}
 
 	// 10. handle --logs flag
@@ -124,12 +113,12 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	case "":
 		// nothing
 	case "-":
-		task.LogsWriter = testableStdout
+		task.LogsWriter = env.Stdout()
 	default:
 		filep, err := os.OpenFile(*logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 		if err != nil {
 			err = fmt.Errorf("cannot open log file: %w", err)
-			fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
+			fmt.Fprintf(env.Stderr(), "rbmk curl: %s\n", err.Error())
 			return err
 		}
 		defer filep.Close()
@@ -141,7 +130,7 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 		filep, err := os.OpenFile(*output, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 		if err != nil {
 			err = fmt.Errorf("cannot create output file: %w", err)
-			fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
+			fmt.Fprintf(env.Stderr(), "rbmk curl: %s\n", err.Error())
 			return err
 		}
 		defer filep.Close()
@@ -150,7 +139,7 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 
 	// 12. run the task
 	if err := task.Run(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "rbmk curl: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "rbmk curl: %s\n", err.Error())
 		return err
 	}
 

--- a/pkg/cli/dig/dig_test.go
+++ b/pkg/cli/dig/dig_test.go
@@ -5,21 +5,24 @@ package dig
 import (
 	"context"
 	"testing"
+
+	"github.com/rbmk-project/common/cliutils"
 )
 
 func TestCommand(t *testing.T) {
+	stdenv := cliutils.StandardEnvironment{}
 	cmd := NewCommand()
 
 	t.Run("help requested from the main command", func(t *testing.T) {
-		cmd.Help()
+		cmd.Help(stdenv)
 	})
 
 	t.Run("help request from the command command line", func(t *testing.T) {
-		cmd.Main(context.Background(), "help")
+		cmd.Main(context.Background(), stdenv, "help")
 	})
 
 	t.Run("normal run", func(t *testing.T) {
-		err := cmd.Main(context.Background(), "dig")
+		err := cmd.Main(context.Background(), stdenv, "dig")
 		if err == nil || err.Error() != "missing name to resolve" {
 			t.Fatalf("expected 'not implemented', got %v", err)
 		}

--- a/pkg/cli/intro/intro.go
+++ b/pkg/cli/intro/intro.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"os"
 
 	"github.com/rbmk-project/common/cliutils"
 )
@@ -21,11 +20,11 @@ func NewCommand() cliutils.Command {
 
 type command struct{}
 
-func (cmd command) Help(argv ...string) error {
-	return cmd.Main(context.Background(), argv...)
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	return cmd.Main(context.Background(), env, argv...)
 }
 
-func (cmd command) Main(ctx context.Context, argv ...string) error {
-	fmt.Fprintf(os.Stdout, "%s\n", readme)
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", readme)
 	return nil
 }

--- a/pkg/cli/ipuniq/ipuniq.go
+++ b/pkg/cli/ipuniq/ipuniq.go
@@ -26,22 +26,22 @@ func NewCommand() cliutils.Command {
 
 type command struct{}
 
-func (cmd command) Help(argv ...string) error {
-	fmt.Fprintf(os.Stdout, "%s\n", readme)
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", readme)
 	return nil
 }
 
-func (cmd command) Main(ctx context.Context, argv ...string) error {
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	// 1. honour requests for printing the help
 	if cliutils.HelpRequested(argv...) {
-		return cmd.Help(argv...)
+		return cmd.Help(env, argv...)
 	}
 
 	// 2. ensure we have at least one file to read
 	if len(argv) < 2 {
 		err := errors.New("expected one or more files containing IP addresses")
-		fmt.Fprintf(os.Stderr, "rbmk ipuniq: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Run `rbmk ipuniq --help` for usage.\n")
+		fmt.Fprintf(env.Stderr(), "rbmk ipuniq: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk ipuniq --help` for usage.\n")
 		return err
 	}
 
@@ -49,7 +49,7 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	ipAddrs := make(map[string]struct{})
 	for _, fname := range argv[1:] {
 		if err := readIPs(fname, ipAddrs); err != nil {
-			fmt.Fprintf(os.Stderr, "rbmk ipuniq: %s\n", err.Error())
+			fmt.Fprintf(env.Stderr(), "rbmk ipuniq: %s\n", err.Error())
 			return err
 		}
 	}
@@ -63,7 +63,7 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
 	for _, s := range shuffled {
-		fmt.Println(s)
+		fmt.Fprintln(env.Stdout(), s)
 	}
 	return nil
 }

--- a/pkg/cli/mkdir/mkdir.go
+++ b/pkg/cli/mkdir/mkdir.go
@@ -24,15 +24,15 @@ func NewCommand() cliutils.Command {
 
 type command struct{}
 
-func (cmd command) Help(argv ...string) error {
-	fmt.Fprintf(os.Stdout, "%s\n", readme)
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", readme)
 	return nil
 }
 
-func (cmd command) Main(ctx context.Context, argv ...string) error {
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	// 1. honour requests for printing the help
 	if cliutils.HelpRequested(argv...) {
-		return cmd.Help(argv...)
+		return cmd.Help(env, argv...)
 	}
 
 	// 2. parse the command line flags
@@ -40,8 +40,8 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	parents := clip.BoolP("parents", "p", false, "create parent directories as needed")
 
 	if err := clip.Parse(argv[1:]); err != nil {
-		fmt.Fprintf(os.Stderr, "rbmk mkdir: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Run `rbmk mkdir --help` for usage.\n")
+		fmt.Fprintf(env.Stderr(), "rbmk mkdir: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk mkdir --help` for usage.\n")
 		return err
 	}
 
@@ -49,8 +49,8 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	args := clip.Args()
 	if len(args) < 1 {
 		err := errors.New("expected one or more directories to create")
-		fmt.Fprintf(os.Stderr, "rbmk mkdir: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Run `rbmk mkdir --help` for usage.\n")
+		fmt.Fprintf(env.Stderr(), "rbmk mkdir: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk mkdir --help` for usage.\n")
 		return err
 	}
 
@@ -61,7 +61,7 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 			mkdirfn = os.MkdirAll
 		}
 		if err := mkdirfn(dir, 0755); err != nil {
-			fmt.Fprintf(os.Stderr, "rbmk mkdir: %s\n", err.Error())
+			fmt.Fprintf(env.Stderr(), "rbmk mkdir: %s\n", err.Error())
 			return err
 		}
 	}

--- a/pkg/cli/rm/rm.go
+++ b/pkg/cli/rm/rm.go
@@ -24,15 +24,15 @@ func NewCommand() cliutils.Command {
 
 type command struct{}
 
-func (cmd command) Help(argv ...string) error {
-	fmt.Fprintf(os.Stdout, "%s\n", readme)
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", readme)
 	return nil
 }
 
-func (cmd command) Main(ctx context.Context, argv ...string) error {
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	// 1. honour requests for printing the help
 	if cliutils.HelpRequested(argv...) {
-		return cmd.Help(argv...)
+		return cmd.Help(env, argv...)
 	}
 
 	// 2. parse command line flags
@@ -41,8 +41,8 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	force := clip.BoolP("force", "f", false, "ignore nonexistent-file errors")
 
 	if err := clip.Parse(argv[1:]); err != nil {
-		fmt.Fprintf(os.Stderr, "rbmk rm: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Run `rbmk rm --help` for usage.\n")
+		fmt.Fprintf(env.Stderr(), "rbmk rm: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk rm --help` for usage.\n")
 		return err
 	}
 
@@ -50,15 +50,15 @@ func (cmd command) Main(ctx context.Context, argv ...string) error {
 	args := clip.Args()
 	if len(args) < 1 {
 		err := errors.New("expected one or more paths to remove")
-		fmt.Fprintf(os.Stderr, "rbmk rm: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Run `rbmk rm --help` for usage.\n")
+		fmt.Fprintf(env.Stderr(), "rbmk rm: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk rm --help` for usage.\n")
 		return err
 	}
 
 	// 4. remove each path
 	for _, path := range args {
 		if err := removePath(path, *recursive, *force); err != nil {
-			fmt.Fprintf(os.Stderr, "rbmk rm: %s\n", err.Error())
+			fmt.Fprintf(env.Stderr(), "rbmk rm: %s\n", err.Error())
 			return err
 		}
 	}

--- a/pkg/cli/timestamp/timestamp.go
+++ b/pkg/cli/timestamp/timestamp.go
@@ -8,7 +8,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/rbmk-project/common/cliutils"
@@ -24,26 +23,26 @@ func NewCommand() cliutils.Command {
 
 type command struct{}
 
-func (cmd command) Help(argv ...string) error {
-	fmt.Fprintf(os.Stdout, "%s\n", readme)
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", readme)
 	return nil
 }
 
-func (cmd command) Main(ctx context.Context, argv ...string) error {
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	// 1. honour requests for printing the help
 	if cliutils.HelpRequested(argv...) {
-		return cmd.Help(argv...)
+		return cmd.Help(env, argv...)
 	}
 
 	// 2. ensure no extra arguments
 	if len(argv) > 1 {
 		err := errors.New("expected no positional arguments")
-		fmt.Fprintf(os.Stderr, "rbmk timestamp: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Run `rbmk timestamp --help` for usage.\n")
+		fmt.Fprintf(env.Stderr(), "rbmk timestamp: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk timestamp --help` for usage.\n")
 		return err
 	}
 
 	// 3. print ISO8601 UTC timestamp in compact format
-	fmt.Fprintf(os.Stdout, "%s\n", time.Now().UTC().Format("20060102T150405Z"))
+	fmt.Fprintf(env.Stdout(), "%s\n", time.Now().UTC().Format("20060102T150405Z"))
 	return nil
 }

--- a/pkg/cli/tutorial/tutorial.go
+++ b/pkg/cli/tutorial/tutorial.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"os"
 
 	"github.com/rbmk-project/common/cliutils"
 )
@@ -21,11 +20,11 @@ func NewCommand() cliutils.Command {
 
 type command struct{}
 
-func (cmd command) Help(argv ...string) error {
-	return cmd.Main(context.Background(), argv...)
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	return cmd.Main(context.Background(), env, argv...)
 }
 
-func (cmd command) Main(ctx context.Context, argv ...string) error {
-	fmt.Fprintf(os.Stdout, "%s\n", readme)
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", readme)
 	return nil
 }


### PR DESCRIPTION
The new clitools uses dependency injection to provide the command Environment for Command.Help and Command.Main.

In turn, the Environment provides the stdout and the stderr.

Update our CLI commands and take advantage of this to simplify how we make the stdout testable in the `./internal/qa` package.

See https://github.com/rbmk-project/common/pull/13