### PR TITLE
fix(rbmk sh): use env.Stdin rather than os.Stdin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.3
 
 require (
 	github.com/miekg/dns v1.1.62
-	github.com/rbmk-project/common v0.10.0
+	github.com/rbmk-project/common v0.11.0
 	github.com/rbmk-project/dnscore v0.8.0
 	github.com/rbmk-project/x v0.0.0-20241130105031-0e28dad87694
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rbmk-project/common v0.10.0 h1:yac4Yt9/1p1eoMo/8dk0TJxmQ5XgnJfC7Qbx5gAbdqU=
-github.com/rbmk-project/common v0.10.0/go.mod h1:BsIum8cGFuNxktk3yWVGlr2B18wtyzn3evb3nhvGyig=
+github.com/rbmk-project/common v0.11.0 h1:ugWLxfqZebw0pZkaDd1ftz4OLsB18huD5SFSTWQ7zbQ=
+github.com/rbmk-project/common v0.11.0/go.mod h1:BsIum8cGFuNxktk3yWVGlr2B18wtyzn3evb3nhvGyig=
 github.com/rbmk-project/dnscore v0.8.0 h1:P5qyH1ZSwafdp4b2zbts2DwwuxZvj2BtnwOe9XhJ0bg=
 github.com/rbmk-project/dnscore v0.8.0/go.mod h1:m56W6xysS/Fru7v/6XaSEc6TNZxKxSO6YmnMIIeCP04=
 github.com/rbmk-project/x v0.0.0-20241130105031-0e28dad87694 h1:DvT/Ln2v6qBIW9zVpwhzXldEi+RcRT8qUZCyr3GWZwc=

--- a/internal/testable/testable.go
+++ b/internal/testable/testable.go
@@ -91,6 +91,9 @@ type Environment struct {
 	// mu protects stderr and stdout.
 	mu sync.Mutex
 
+	// stdin is the standard input stream.
+	stdin io.Reader
+
 	// stderr is the standard error stream.
 	stderr io.Writer
 
@@ -102,9 +105,17 @@ type Environment struct {
 func NewEnvironment() *Environment {
 	return &Environment{
 		mu:     sync.Mutex{},
+		stdin:  os.Stdin,
 		stderr: os.Stderr,
 		stdout: os.Stdout,
 	}
+}
+
+// SetStdin sets the standard input stream.
+func (env *Environment) SetStdin(r io.Reader) {
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	env.stdin = r
 }
 
 // SetStderr sets the standard error stream.
@@ -123,6 +134,13 @@ func (env *Environment) SetStdout(w io.Writer) {
 
 // Ensure that [*Environment] implements [cliutils.Environment].
 var _ cliutils.Environment = (*Environment)(nil)
+
+// Stdin implements [cliutils.Environment].
+func (env *Environment) Stdin() io.Reader {
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	return env.stdin
+}
 
 // Stderr implements [cliutils.Environment].
 func (env *Environment) Stderr() io.Writer {

--- a/pkg/cli/sh/sh.go
+++ b/pkg/cli/sh/sh.go
@@ -75,7 +75,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 
 	// 5. Create the shell interpreter.
 	runner, err := interp.New(
-		interp.StdIO(os.Stdin, env.Stdout(), env.Stderr()),
+		interp.StdIO(env.Stdin(), env.Stdout(), env.Stderr()),
 		interp.Env(expand.FuncEnviron(os.Getenv)),
 	)
 	if err != nil {


### PR DESCRIPTION
This change is mainly for correctness. Ensure we always use the env.Stdin rather than os.Stdin directly, to avoid surprises when we start composing and executing commands without actually spawning a new process but rather as internally running commands. The only place where we were using os.Stdin directly was the `rbmk sh` subcommand.

See also https://github.com/rbmk-project/common/pull/14