### PR TITLE
feat(rbmk): implement the mv subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Unix-like Commands for Scripting:
 - `cat`: Concatenates files.
 - `ipuniq`: Filter out duplicate IP addresses.
 - `mkdir`: Creates directories.
+- `mv`: Moves (renames) files and directories.
 - `rm`: Removes files and directories.
 - `sh`: Runs POSIX shell scripts.
 - `tar`: Creates tar archives.

--- a/pkg/cli/README.txt
+++ b/pkg/cli/README.txt
@@ -12,6 +12,7 @@ Unix-like commands for scripting:
     cat       Concatenates files to standard output.
     ipuniq    Filters out duplicate IP addresses.
     mkdir     Creates directories.
+    mv        Moves (renames) files and directories.
     rm        Removes files and directories.
     sh        Runs POSIX shell scripts.
     tar       Creates tar archives.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rbmk-project/rbmk/pkg/cli/intro"
 	"github.com/rbmk-project/rbmk/pkg/cli/ipuniq"
 	"github.com/rbmk-project/rbmk/pkg/cli/mkdir"
+	"github.com/rbmk-project/rbmk/pkg/cli/mv"
 	"github.com/rbmk-project/rbmk/pkg/cli/rm"
 	"github.com/rbmk-project/rbmk/pkg/cli/sh"
 	"github.com/rbmk-project/rbmk/pkg/cli/tar"
@@ -32,6 +33,7 @@ func NewCommand() cliutils.Command {
 		"intro":     intro.NewCommand(),
 		"ipuniq":    ipuniq.NewCommand(),
 		"mkdir":     mkdir.NewCommand(),
+		"mv":        mv.NewCommand(),
 		"rm":        rm.NewCommand(),
 		"sh":        sh.NewCommand(),
 		"tar":       tar.NewCommand(),

--- a/pkg/cli/mv/README.txt
+++ b/pkg/cli/mv/README.txt
@@ -1,0 +1,17 @@
+usage: rbmk mv [-f] SOURCE... DESTINATION
+
+Move (rename) SOURCE to DESTINATION. When moving multiple SOURCE files,
+the DESTINATION must be an existing directory.
+
+We currently support the following command line flags:
+
+    -h, --help
+        Print this help message.
+
+For example, to move a file:
+    $ rbmk mv source.txt destination.txt
+
+To move multiple files into a directory:
+    $ rbmk mv file1.txt file2.txt target_directory/
+
+This command exits with `0` on success and `1` on failure.

--- a/pkg/cli/mv/README.txt
+++ b/pkg/cli/mv/README.txt
@@ -1,3 +1,4 @@
+
 usage: rbmk mv [-f] SOURCE... DESTINATION
 
 Move (rename) SOURCE to DESTINATION. When moving multiple SOURCE files,

--- a/pkg/cli/mv/mv.go
+++ b/pkg/cli/mv/mv.go
@@ -62,7 +62,11 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 	if len(sources) > 1 {
 		// Check if destination is a directory
 		destInfo, err := os.Stat(dest)
-		if err != nil || !destInfo.IsDir() {
+		if err != nil {
+			fmt.Fprintf(env.Stderr(), "rbmk mv: %s\n", err.Error())
+			return err
+		}
+		if !destInfo.IsDir() {
 			err := errors.New("destination must be a directory when moving multiple sources")
 			fmt.Fprintf(env.Stderr(), "rbmk mv: %s\n", err.Error())
 			return err

--- a/pkg/cli/mv/mv.go
+++ b/pkg/cli/mv/mv.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package mv implements the `rbmk mv` command.
+package mv
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rbmk-project/common/cliutils"
+	"github.com/spf13/pflag"
+)
+
+//go:embed README.txt
+var readme string
+
+// NewCommand creates the `rbmk mv` Command.
+func NewCommand() cliutils.Command {
+	return command{}
+}
+
+type command struct{}
+
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", readme)
+	return nil
+}
+
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
+	// 1. honour requests for printing the help
+	if cliutils.HelpRequested(argv...) {
+		return cmd.Help(env, argv...)
+	}
+
+	// 2. parse command line flags
+	clip := pflag.NewFlagSet("rbmk mv", pflag.ContinueOnError)
+
+	if err := clip.Parse(argv[1:]); err != nil {
+		fmt.Fprintf(env.Stderr(), "rbmk mv: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk mv --help` for usage.\n")
+		return err
+	}
+
+	// 3. ensure we have at least two arguments
+	args := clip.Args()
+	if len(args) < 2 {
+		err := errors.New("missing source and/or destination")
+		fmt.Fprintf(env.Stderr(), "rbmk mv: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk mv --help` for usage.\n")
+		return err
+	}
+
+	// 4. get sources and destination
+	sources := args[:len(args)-1]
+	dest := args[len(args)-1]
+
+	// 5. handle multiple sources case
+	if len(sources) > 1 {
+		// Check if destination is a directory
+		destInfo, err := os.Stat(dest)
+		if err != nil || !destInfo.IsDir() {
+			err := errors.New("destination must be a directory when moving multiple sources")
+			fmt.Fprintf(env.Stderr(), "rbmk mv: %s\n", err.Error())
+			return err
+		}
+	}
+
+	// 6. process each source
+	for _, src := range sources {
+		target := dest
+		if fi, err := os.Stat(dest); err == nil && fi.IsDir() {
+			target = filepath.Join(dest, filepath.Base(src))
+		}
+
+		if err := os.Rename(src, target); err != nil {
+			fmt.Fprintf(env.Stderr(), "rbmk mv: %s\n", err.Error())
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cli/mv/mv.go
+++ b/pkg/cli/mv/mv.go
@@ -61,12 +61,12 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 	// 5. handle multiple sources case
 	if len(sources) > 1 {
 		// Check if destination is a directory
-		destInfo, err := os.Stat(dest)
+		finfo, err := os.Stat(dest)
 		if err != nil {
 			fmt.Fprintf(env.Stderr(), "rbmk mv: %s\n", err.Error())
 			return err
 		}
-		if !destInfo.IsDir() {
+		if !finfo.IsDir() {
 			err := errors.New("destination must be a directory when moving multiple sources")
 			fmt.Fprintf(env.Stderr(), "rbmk mv: %s\n", err.Error())
 			return err
@@ -75,16 +75,17 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 
 	// 6. process each source
 	for _, src := range sources {
+		// ensure we move inside directory if last element is a directory
 		target := dest
-		if fi, err := os.Stat(dest); err == nil && fi.IsDir() {
+		if findo, err := os.Stat(dest); err == nil && findo.IsDir() {
 			target = filepath.Join(dest, filepath.Base(src))
 		}
 
+		// actually rename the file
 		if err := os.Rename(src, target); err != nil {
 			fmt.Fprintf(env.Stderr(), "rbmk mv: %s\n", err.Error())
 			return err
 		}
 	}
-
 	return nil
 }


### PR DESCRIPTION
This diff adds a minimal implementation of the mv subcommand, mostly useful for scripts to move measurement results somewhere else. See https://github.com/rbmk-project/rbmk-project.github.io/pull/13.