### PR TITLE
feat(ipuniq): implement formatting endpoints

### DIFF
--- a/pkg/cli/ipuniq/README.txt
+++ b/pkg/cli/ipuniq/README.txt
@@ -1,5 +1,5 @@
 
-usage: rbmk ipuniq FILE...
+usage: rbmk ipuniq [flags] FILE...
 
 Read IP addresses from files, sort them, and remove duplicates. We expect
 input files to contain one IP address per line.
@@ -14,6 +14,19 @@ More specifically, `rbmk ipuniq`:
 
     - Randomly shuffles the resulting addresses
 
+We currently support the following command line flags:
+
+    -h, --help
+        Print this help message.
+
+    -p, --port PORT
+        Format output as HOST:PORT endpoints, adding [] brackets for IPv6
+        addresses as needed. This flag can be specified multiple times
+        to generate endpoints for multiple ports (e.g., `-p 80 -p 443 -p 22`
+        generates HTTP, HTTPS, and SSH endpoints). When no ports are
+        specified, we output IP addresses without ports. Each PORT must
+        be a valid port number (0-65535).
+
 This command is useful to process the output of several
 `rbmk dig` invocations that return IP addresses to create
 a unique list of IP addresses to measure. For example:
@@ -25,5 +38,17 @@ a unique list of IP addresses to measure. For example:
     $ for ipAddr in $(rbmk ipuniq dig_A.txt dig_AAAA.txt); do \
         rbmk curl --resolve "example.com:443:${ipAddr}" https://example.com/ \
     done
+
+You can also use this command to generate STUN endpoints to measure:
+
+    $ rbmk dig +short=ip stun.l.google.com A > ips.txt
+
+    $ rbmk dig +short=ip stun.l.google.com AAAA >> ips.txt
+
+    $ rbmk ipuniq --port 19302 stun_A.txt stun_AAAA.txt
+
+You can also generate multiple endpoints for the same IP address:
+
+    $ rbmk ipuniq --port 80 --port 443 ips.txt
 
 This command exits with `0` on success and `1` on failure.

--- a/pkg/cli/ipuniq/ipuniq.go
+++ b/pkg/cli/ipuniq/ipuniq.go
@@ -12,8 +12,10 @@ import (
 	"math/rand/v2"
 	"net"
 	"os"
+	"strconv"
 
 	"github.com/rbmk-project/common/cliutils"
+	"github.com/spf13/pflag"
 )
 
 //go:embed README.txt
@@ -37,24 +39,46 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 		return cmd.Help(env, argv...)
 	}
 
-	// 2. ensure we have at least one file to read
-	if len(argv) < 2 {
+	// 2. parse command line flags
+	clip := pflag.NewFlagSet("rbmk ipuniq", pflag.ContinueOnError)
+	fports := clip.StringSliceP("port", "p", nil, "format output as HOST:PORT endpoints")
+
+	if err := clip.Parse(argv[1:]); err != nil {
+		fmt.Fprintf(env.Stderr(), "rbmk ipuniq: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk ipuniq --help` for usage.\n")
+		return err
+	}
+
+	// 3. ensures all the ports are valid
+	var ports []uint16
+	for _, port := range *fports {
+		value, err := strconv.ParseUint(port, 10, 16)
+		if err != nil {
+			fmt.Fprintf(env.Stderr(), "rbmk ipuniq: %s\n", err.Error())
+			return err
+		}
+		ports = append(ports, uint16(value))
+	}
+
+	// 4. ensure we have at least one file to read
+	args := clip.Args()
+	if len(args) < 1 {
 		err := errors.New("expected one or more files containing IP addresses")
 		fmt.Fprintf(env.Stderr(), "rbmk ipuniq: %s\n", err.Error())
 		fmt.Fprintf(env.Stderr(), "Run `rbmk ipuniq --help` for usage.\n")
 		return err
 	}
 
-	// 3. read and parse IPs from all files
+	// 5. read and parse IPs from all files
 	ipAddrs := make(map[string]struct{})
-	for _, fname := range argv[1:] {
+	for _, fname := range args {
 		if err := readIPs(fname, ipAddrs); err != nil {
 			fmt.Fprintf(env.Stderr(), "rbmk ipuniq: %s\n", err.Error())
 			return err
 		}
 	}
 
-	// 4. randomly shuffle and print unique IPs
+	// 6. randomly shuffle and print unique IPs w/ optional port
 	var shuffled []string
 	for s := range ipAddrs {
 		shuffled = append(shuffled, s)
@@ -63,7 +87,14 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
 	for _, s := range shuffled {
-		fmt.Fprintln(env.Stdout(), s)
+		if len(ports) <= 0 {
+			fmt.Fprintln(env.Stdout(), s)
+			continue
+		}
+		for _, port := range ports {
+			epnt := net.JoinHostPort(s, strconv.FormatUint(uint64(port), 10))
+			fmt.Fprintln(env.Stdout(), epnt)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This diff adds to `rbmk ipuniq` the `-p, --port` flag that allows one to construct unique endpoints rather than IP addresses.

This functionality is useful to automatically and easily building unique endpoints given possibly-duplicate IP addresses.

The `-p, --port` flag may be specified multiple times to generate multiple endpoints for a given set of addresses.