### PR TITLE
fix: remove the Research directory b/c it conflicts w/ `./r<tab>`

### DIFF
--- a/Research/.gitignore
+++ b/Research/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
It starts with `./R` which conflicts with `./r<tab>` to get autocompletion to `./rbmk` so it's a no no no no.

I will continue using the experimental branch to figure out a naming pattern than works w/o conflicts.