### PR TITLE
feat(curl,dig,stun): implement the --measure flag

### DIFF
--- a/pkg/cli/curl/README.md
+++ b/pkg/cli/curl/README.md
@@ -31,6 +31,14 @@ Sets the maximum time that the transfer operation is allowed to take
 in seconds (e.g., `--max-time 5`). If this flag is not specified, the
 default max time is 30 seconds.
 
+### `--measure`
+
+Do not exit with `1` if communication with the server fails. Only exit
+with `1` in case of usage errors, or failure to process inputs. You should
+use this flag inside measurement scripts along with `set -e`. Errors are
+still printed to stderr along with a note indicating that the command is
+continuing due to this flag.
+
 ### `-o, --output FILE`
 
 Write the response body to FILE instead of using the stdout.
@@ -76,4 +84,10 @@ To use a previously resolved IP address, use `--resolve`:
 
 ## Exit Status
 
-This command exits with `0` on success and `1` on failure.
+Returns `0` on success. Returns `1` on:
+
+- Usage errors (invalid flags, missing arguments, etc).
+
+- File operation errors (cannot open/close files).
+
+- Measurement failures (unless `--measure` is specified).

--- a/pkg/cli/dig/README.md
+++ b/pkg/cli/dig/README.md
@@ -10,15 +10,14 @@ rbmk dig [flags] [@SERVER] NAME [TYPE] [options]
 ## Description
 
 The `rbmk dig` command emulate a subset of the `dig(1)` command. By default, we
-print output on the standard output emulating what `dig(1)` would print.
+print output on the standard output emulating what `dig(1)` would print. All queries
+timeout after five seconds by default.
 
 Command line flags start with the `-` character, while query-specific
 options start with the `+` character, just like in `dig(1)`.
 
 Flags MUST come first. The relative order of `@SERVER`, `NAME`, `TYPE`, and
 `+options` is not significant, as long as they come after the flags.
-
-Note that, by default, the query will timeout after five seconds.
 
 ## Arguments
 
@@ -66,6 +65,14 @@ Writes structured logs to the given FILE. If FILE already exists, we
 append to it. If FILE does not exist, we create it. If FILE is a single
 dash (`-`), we write to the stdout. If you specify `--logs` multiple
 times, we write to the last FILE specified.
+
+### `--measure`
+
+Do not exit with `1` if communication with the server fails. Only exit
+with `1` in case of usage errors, or failure to process inputs. You should
+use this flag inside measurement scripts along with `set -e`. Errors are
+still printed to stderr along with a note indicating that the command is
+continuing due to this flag.
 
 ### Query Options
 
@@ -135,4 +142,10 @@ $ rbmk dig --logs LOGS.jsonl www.example.com MX
 
 ## Exit Status
 
-This command exits with `0` on success and `1` on failure.
+Returns `0` on success. Returns `1` on:
+
+- Usage errors (invalid flags, missing arguments, etc).
+
+- File operation errors (cannot open/close files).
+
+- Measurement failures (unless `--measure` is specified).

--- a/pkg/cli/stun/README.md
+++ b/pkg/cli/stun/README.md
@@ -39,6 +39,14 @@ Writes structured logs to the given FILE. If FILE already exists, we
 append to it. If FILE does not exist, we create it. If FILE is a single
 dash (`-`), we write to the stdout.
 
+### `--measure`
+
+Do not exit with `1` if communication with the endpoint fails. Only exit
+with `1` in case of usage errors, or failure to process inputs. You should
+use this flag inside measurement scripts along with `set -e`. Errors are
+still printed to stderr along with a note indicating that the command is
+continuing due to this flag.
+
 ## Examples
 
 Basic usage:
@@ -56,4 +64,10 @@ $ rbmk stun --logs stun.jsonl 74.125.250.129:19302
 
 ## Exit Status
 
-This command exits with `0` on success and `1` on failure.
+Returns `0` on success. Returns `1` on:
+
+- Usage errors (invalid flags, missing arguments, etc).
+
+- File operation errors (cannot open/close files).
+
+- Measurement failures (unless `--measure` is specified).


### PR DESCRIPTION
The `--measure` flag suppresses errors when measuring and transforms them in warnings, thus allowing to use these commands safely inside scripts using `set -e`.