### PR TITLE
fix(curl,dig,stun): invert --measure logic checks

### DIFF
--- a/pkg/cli/curl/curl.go
+++ b/pkg/cli/curl/curl.go
@@ -143,7 +143,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 
 	// 12. run the task and honour the `--measure` flag
 	err := task.Run(ctx)
-	if err != nil && !*measure {
+	if err != nil && *measure {
 		fmt.Fprintf(env.Stderr(), "rbmk curl: %s\n", err.Error())
 		fmt.Fprintf(env.Stderr(), "rbmk curl: not failing because you specified --measure\n")
 		err = nil

--- a/pkg/cli/dig/dig.go
+++ b/pkg/cli/dig/dig.go
@@ -205,7 +205,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 
 	// 9. run the task and honour the `--measure` flag
 	err := task.Run(ctx)
-	if err != nil && !*measure {
+	if err != nil && *measure {
 		fmt.Fprintf(env.Stderr(), "rbmk dig: %s\n", err.Error())
 		fmt.Fprintf(env.Stderr(), "rbmk dig: not failing because you specified --measure\n")
 		err = nil

--- a/pkg/cli/stun/stun.go
+++ b/pkg/cli/stun/stun.go
@@ -92,7 +92,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 
 	// 9. run the task and honour the `--measure` flag
 	err := task.Run(ctx)
-	if err != nil && !*measure {
+	if err != nil && *measure {
 		fmt.Fprintf(env.Stderr(), "rbmk stun: %s\n", err.Error())
 		fmt.Fprintf(env.Stderr(), "rbmk stun: not failing because you specified --measure\n")
 		err = nil


### PR DESCRIPTION
Currently curl, dig, and stun had wrong logic with respect to handling the `--measure` flag. Fix by inverting the logic.