### PR TITLE
BREAKING CHANGE(ipuniq): stream addresses by default

### DIFF
--- a/pkg/cli/ipuniq/README.md
+++ b/pkg/cli/ipuniq/README.md
@@ -4,23 +4,28 @@
 ## Usage
 
 ```
-rbmk ipuniq [flags] FILE...
+rbmk ipuniq [flags] [FILE...]
 ```
 
 ## Description
 
-Read IP addresses from files, sort them, and remove duplicates. We expect
-input files to contain one IP address per line.
+Read IP addresses from files or stdin and remove duplicates. We expect
+input files, or stdin, to contain one IP address per line. Use `-` as the
+file name to explicitly indicate you want to read from the stdin.
 
 More specifically, `rbmk ipuniq`:
 
-- Reads IPv4 and IPv6 addresses from input files
+- Reads IPv4 and IPv6 addresses from input files or the stdin
 
 - Normalizes different textual representations
 
 - Removes duplicates
 
-- Randomly shuffles the resulting addresses
+- Optionally, randomly shuffles the resulting addresses
+
+You enable random shuffling with `--random`. When not using `--random`, we
+stream unique addresses as soon as they are read. The streaming functionality
+was implemented in RBMK v0.4.0.
 
 ## Flags
 
@@ -37,6 +42,11 @@ generates HTTP, HTTPS, and SSH endpoints). When no ports are
 specified, we output IP addresses without ports. Each PORT must
 be a valid port number (0-65535).
 
+### `-r, --random`
+
+Buffers and randomly shuffles the addresses before output. This
+flag has been introduced in v0.4.0.
+
 ## Examples
 
 ### Process DNS Resolution Results
@@ -51,6 +61,18 @@ $ rbmk dig + short=ip example.com AAAA > dig_AAAA.txt
 $ for ipAddr in $(rbmk ipuniq dig_A.txt dig_AAAA.txt); do \
   rbmk curl --resolve "example.com:443:${ipAddr}" https://example.com/ \
 done
+```
+
+Randomize IP addresses read from stdin:
+
+```
+$ rbmk ipuniq --random
+```
+
+Filters stdin and immediately emits unique addresses:
+
+```
+$ rbmk ipuniq
 ```
 
 ### Generate STUN Endpoints
@@ -76,3 +98,8 @@ $ rbmk ipuniq --port 80 --port 443 ips.txt
 ### Exit Status
 
 This command exits with `0` on success and `1` on failure.
+
+### History
+
+Before RBMK v0.4.0, this command always randomly shuffled the
+addresses. Afterwards, one must use `--random` explicitly.

--- a/pkg/cli/ipuniq/ipuniq.go
+++ b/pkg/cli/ipuniq/ipuniq.go
@@ -7,8 +7,8 @@ import (
 	"bufio"
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
+	"io"
 	"math/rand/v2"
 	"net"
 	"os"
@@ -43,6 +43,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 	// 2. parse command line flags
 	clip := pflag.NewFlagSet("rbmk ipuniq", pflag.ContinueOnError)
 	fports := clip.StringSliceP("port", "p", nil, "format output as HOST:PORT endpoints")
+	frand := clip.BoolP("random", "r", false, "randomly shuffle the output")
 
 	if err := clip.Parse(argv[1:]); err != nil {
 		fmt.Fprintf(env.Stderr(), "rbmk ipuniq: %s\n", err.Error())
@@ -61,25 +62,28 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 		ports = append(ports, uint16(value))
 	}
 
-	// 4. ensure we have at least one file to read
+	// 4. collect the files to read IPs from, if any. Otherwise,
+	// we will read the addresses from the standard input.
 	args := clip.Args()
-	if len(args) < 1 {
-		err := errors.New("expected one or more files containing IP addresses")
-		fmt.Fprintf(env.Stderr(), "rbmk ipuniq: %s\n", err.Error())
-		fmt.Fprintf(env.Stderr(), "Run `rbmk ipuniq --help` for usage.\n")
-		return err
+	if len(args) <= 0 {
+		args = append(args, "-")
 	}
 
 	// 5. read and parse IPs from all files
 	ipAddrs := make(map[string]struct{})
 	for _, fname := range args {
-		if err := readIPs(fname, ipAddrs); err != nil {
+		if err := readIPs(env, fname, *frand, ipAddrs, ports); err != nil {
 			fmt.Fprintf(env.Stderr(), "rbmk ipuniq: %s\n", err.Error())
 			return err
 		}
 	}
 
-	// 6. randomly shuffle and print unique IPs w/ optional port
+	// 6. if streaming, stop now
+	if !*frand {
+		return nil
+	}
+
+	// 7. otherwise randomly shuffle and print unique IPs w/ optional port
 	var shuffled []string
 	for s := range ipAddrs {
 		shuffled = append(shuffled, s)
@@ -88,34 +92,60 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
 	for _, s := range shuffled {
-		if len(ports) <= 0 {
-			fmt.Fprintln(env.Stdout(), s)
-			continue
-		}
-		for _, port := range ports {
-			epnt := net.JoinHostPort(s, strconv.FormatUint(uint64(port), 10))
-			fmt.Fprintln(env.Stdout(), epnt)
-		}
+		printAddr(env, s, ports)
 	}
 	return nil
 }
 
-// readIPs reads IP addresses from the given file into the given map.
-func readIPs(fname string, ipAddrs map[string]struct{}) error {
-	filep, err := os.Open(fname)
-	if err != nil {
-		return err
+// readIPs reads IP addresses from the given file into the given map
+// and possibly streams them immediately if `frand` is false.
+func readIPs(
+	env cliutils.Environment,
+	fname string,
+	frand bool,
+	ipAddrs map[string]struct{},
+	ports []uint16,
+) error {
+	var reader io.Reader
+	if fname != "-" {
+		filep, err := os.Open(fname)
+		if err != nil {
+			return err
+		}
+		defer filep.Close()
+		reader = filep
+	} else {
+		reader = os.Stdin
 	}
-	defer filep.Close()
 
-	scanner := bufio.NewScanner(filep)
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if ip := net.ParseIP(line); ip != nil {
 			// Implementation note: using string representation as the key to
 			// handle different textual representations of same addr.
-			ipAddrs[ip.String()] = struct{}{}
+			normalized := ip.String()
+			if _, ok := ipAddrs[normalized]; ok {
+				continue
+			}
+			ipAddrs[normalized] = struct{}{}
+			if frand {
+				continue
+			}
+			printAddr(env, normalized, ports)
 		}
 	}
 	return scanner.Err()
+}
+
+// printAddr prints the address with optional port(s).
+func printAddr(env cliutils.Environment, addr string, ports []uint16) {
+	if len(ports) <= 0 {
+		fmt.Fprintln(env.Stdout(), addr)
+		return
+	}
+	for _, port := range ports {
+		epnt := net.JoinHostPort(addr, strconv.FormatUint(uint64(port), 10))
+		fmt.Fprintln(env.Stdout(), epnt)
+	}
 }


### PR DESCRIPTION
This change modifies how ipuniq works:

1. we now accept reading from stdin explicitly (with `-`) or implicitly by not providing any file to read

2. you now need `-r, --random` to enable randomization (previously always enabled by default)

3. when you enable randomization, we don't stream (obviously, since we need to buffer the output)

We implement this change to allow streaming addresses as soon as they are available through `rbmk pipe`, which improves performance in measurement pipelines.