### PR TITLE
fix: avoid garbled shell output with background commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/miekg/dns v1.1.62
 	github.com/pion/stun/v3 v3.0.0
-	github.com/rbmk-project/common v0.11.0
+	github.com/rbmk-project/common v0.12.0
 	github.com/rbmk-project/dnscore v0.8.0
 	github.com/rbmk-project/x v0.0.0-20241130105031-0e28dad87694
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/pion/transport/v3 v3.0.7 h1:iRbMH05BzSNwhILHoBoAPxoB9xQgOaJk+591KC9P1
 github.com/pion/transport/v3 v3.0.7/go.mod h1:YleKiTZ4vqNxVwh77Z0zytYi7rXHl7j6uPLGhhz9rwo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rbmk-project/common v0.11.0 h1:ugWLxfqZebw0pZkaDd1ftz4OLsB18huD5SFSTWQ7zbQ=
-github.com/rbmk-project/common v0.11.0/go.mod h1:BsIum8cGFuNxktk3yWVGlr2B18wtyzn3evb3nhvGyig=
+github.com/rbmk-project/common v0.12.0 h1:SxznKYj+HHDSTQLZYjVw/S+rQx+NzNUnATttoWQLiKw=
+github.com/rbmk-project/common v0.12.0/go.mod h1:BsIum8cGFuNxktk3yWVGlr2B18wtyzn3evb3nhvGyig=
 github.com/rbmk-project/dnscore v0.8.0 h1:P5qyH1ZSwafdp4b2zbts2DwwuxZvj2BtnwOe9XhJ0bg=
 github.com/rbmk-project/dnscore v0.8.0/go.mod h1:m56W6xysS/Fru7v/6XaSEc6TNZxKxSO6YmnMIIeCP04=
 github.com/rbmk-project/x v0.0.0-20241130105031-0e28dad87694 h1:DvT/Ln2v6qBIW9zVpwhzXldEi+RcRT8qUZCyr3GWZwc=

--- a/internal/markdown/doc.go
+++ b/internal/markdown/doc.go
@@ -2,7 +2,7 @@
 
 // Package markdown contains code to optionally render markdown files.
 //
-// If you compile with `go build -tags rbmk_disable_markdown`, the [TryRender]
+// If you compile with `go build -tags rbmk_disable_markdown`, the [MaybeRender]
 // function won't try to render the markdown content and will return the original
 // content unmodified.
 package markdown

--- a/internal/markdown/lazy.go
+++ b/internal/markdown/lazy.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package markdown
+
+import "github.com/rbmk-project/common/cliutils"
+
+// LazyMaybeRender returns a [cliutils.LazyHelpRenderer] that
+// attempts to render the provide help string using markdown by
+// calling [MaybeRender] when the help is requested.
+func LazyMaybeRender(help string) cliutils.LazyHelpRenderer {
+	return cliutils.LazyHelpRendererFunc(func() string {
+		return MaybeRender(help)
+	})
+}

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -7,9 +7,9 @@ package markdown
 
 import "github.com/charmbracelet/glamour"
 
-// TryRender tries to render the given markdown content. On error,
+// MaybeRender tries to render the given markdown content. On error,
 // it returns the original unmodified content.
-func TryRender(content string) string {
+func MaybeRender(content string) string {
 	render, err := glamour.NewTermRenderer(glamour.WithAutoStyle(), glamour.WithPreservedNewLines())
 	if err != nil {
 		return content

--- a/internal/markdown/nomarkdown.go
+++ b/internal/markdown/nomarkdown.go
@@ -4,8 +4,8 @@
 
 package markdown
 
-// TryRender tries to render the given markdown content. On error,
+// MaybeRender tries to render the given markdown content. On error,
 // it returns the original unmodified content.
-func TryRender(content string) string {
+func MaybeRender(content string) string {
 	return content
 }

--- a/pkg/cli/cat/cat.go
+++ b/pkg/cli/cat/cat.go
@@ -26,7 +26,7 @@ func NewCommand() cliutils.Command {
 type command struct{}
 
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -30,7 +30,7 @@ var readme string
 // NewCommand constructs a new [cliutils.Command] for the `rbmk` command.
 func NewCommand() cliutils.Command {
 	return cliutils.NewCommandWithSubCommands(
-		"rbmk", markdown.TryRender(readme),
+		"rbmk", markdown.LazyMaybeRender(readme),
 		map[string]cliutils.Command{
 			"cat":       cat.NewCommand(),
 			"curl":      curl.NewCommand(),

--- a/pkg/cli/curl/curl.go
+++ b/pkg/cli/curl/curl.go
@@ -31,7 +31,7 @@ var readme string
 
 // Help implements cliutils.Command.
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/dig/dig.go
+++ b/pkg/cli/dig/dig.go
@@ -33,7 +33,7 @@ var readme string
 
 // Help implements [cliutils.Command].
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/intro/intro.go
+++ b/pkg/cli/intro/intro.go
@@ -26,6 +26,6 @@ func (cmd command) Help(env cliutils.Environment, argv ...string) error {
 }
 
 func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }

--- a/pkg/cli/ipuniq/ipuniq.go
+++ b/pkg/cli/ipuniq/ipuniq.go
@@ -30,7 +30,7 @@ func NewCommand() cliutils.Command {
 type command struct{}
 
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/mkdir/mkdir.go
+++ b/pkg/cli/mkdir/mkdir.go
@@ -26,7 +26,7 @@ func NewCommand() cliutils.Command {
 type command struct{}
 
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/mv/mv.go
+++ b/pkg/cli/mv/mv.go
@@ -27,7 +27,7 @@ func NewCommand() cliutils.Command {
 type command struct{}
 
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/pipe/pipe.go
+++ b/pkg/cli/pipe/pipe.go
@@ -16,7 +16,7 @@ var readme string
 // NewCommand creates the `rbmk pipe` Command.
 func NewCommand() cliutils.Command {
 	return cliutils.NewCommandWithSubCommands(
-		"pipe", markdown.TryRender(readme),
+		"pipe", markdown.LazyMaybeRender(readme),
 		map[string]cliutils.Command{
 			"read":  newReadCommand(),
 			"write": newWriteCommand(),

--- a/pkg/cli/pipe/read.go
+++ b/pkg/cli/pipe/read.go
@@ -33,7 +33,7 @@ var readDocs string
 
 // Help implements [cliutils.Command].
 func (cmd readCommand) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readDocs))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readDocs))
 	return nil
 }
 

--- a/pkg/cli/pipe/write.go
+++ b/pkg/cli/pipe/write.go
@@ -30,7 +30,7 @@ var writeDocs string
 
 // Help implements [cliutils.Command].
 func (cmd writeCommand) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(writeDocs))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(writeDocs))
 	return nil
 }
 

--- a/pkg/cli/rm/rm.go
+++ b/pkg/cli/rm/rm.go
@@ -26,7 +26,7 @@ func NewCommand() cliutils.Command {
 type command struct{}
 
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/sh/sh.go
+++ b/pkg/cli/sh/sh.go
@@ -29,7 +29,7 @@ func NewCommand() cliutils.Command {
 type command struct{}
 
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/stun/stun.go
+++ b/pkg/cli/stun/stun.go
@@ -29,7 +29,7 @@ type command struct{}
 
 // Help implements [cliutils.Command].
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/tar/tar.go
+++ b/pkg/cli/tar/tar.go
@@ -36,7 +36,7 @@ func NewCommand() cliutils.Command {
 type command struct{}
 
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/timestamp/timestamp.go
+++ b/pkg/cli/timestamp/timestamp.go
@@ -25,7 +25,7 @@ func NewCommand() cliutils.Command {
 type command struct{}
 
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
-	fmt.Fprintf(env.Stdout(), "%s\n", markdown.TryRender(readme))
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 

--- a/pkg/cli/tutorial/tutorial.go
+++ b/pkg/cli/tutorial/tutorial.go
@@ -66,7 +66,7 @@ var topics = map[string]topicInfo{
 func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	switch {
 	case len(argv) <= 1 || cliutils.HelpRequested(argv...):
-		fmt.Fprintln(env.Stdout(), markdown.TryRender(readme))
+		fmt.Fprintln(env.Stdout(), markdown.MaybeRender(readme))
 		return nil
 
 	case len(argv) > 2:
@@ -83,7 +83,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 			fmt.Fprintf(env.Stderr(), "Run 'rbmk tutorial' to see available topics.\n")
 			return err
 		}
-		fmt.Fprintln(env.Stdout(), markdown.TryRender(topic.content))
+		fmt.Fprintln(env.Stdout(), markdown.MaybeRender(topic.content))
 		return nil
 	}
 }


### PR DESCRIPTION
Before this diff was commited, the following script:

```bash
(./rbmk dig +short +udp=wait-duplicates example.com | ./rbmk pipe write addrs) &

./rbmk pipe read --writers 1 addrs | ./rbmk ipuniq

wait
```

was causing garbled output including ANSI escape sequences emitted by the `rbmk pipe` command. We traced the problem to automatic detection of the terminal capabilities by the markdown rendering library.

In turn, the issue was that we were always rendering the markdown for cliutils.CommandWithSubCommands even when we were not needing it.

To fix this issue, we:

1. adapted rbmk-project/common (in https://github.com/rbmk-project/common/pull/15)

2. updated `./internal/markdown` and commands using CommandWithSubCommands to use conditiional markdown rendering

After these changes, the issue has disappeared.