### PR TITLE
BREAKING CHANGE(Makefile): rbmk-small => rbmk-lite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
 /rbmk
-/rbmk-small
+/rbmk-lite

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ help:
 	@cat Makefile | grep -E '^#doc:' | sed -e 's/^#doc: //g' -e 's/^#doc://'
 
 #doc:
-#doc: - `all`: builds `rbmk` and `rbmk-small`
+#doc: - `all`: builds `rbmk` and `rbmk-lite`
 .PHONY: all
-all: rbmk rbmk-small
+all: rbmk rbmk-lite
 
 #doc:
 #doc: - `rbmk`: build rbmk in the current directory
@@ -20,10 +20,10 @@ rbmk:
 	go build -v -o rbmk -ldflags '-s -w' -tags netgo ./cmd/rbmk
 
 #doc:
-#doc: - `rbmk-small`: build rbmk without optional features in the current dir
-.PHONY: rbmk-small
-rbmk-small:
-	go build -v -o rbmk-small -ldflags '-s -w' -tags rbmk_disable_markdown,netgo ./cmd/rbmk
+#doc: - `rbmk-lite`: build rbmk without optional features in the current dir
+.PHONY: rbmk-lite
+rbmk-lite:
+	go build -v -o rbmk-lite -ldflags '-s -w' -tags rbmk_disable_markdown,netgo ./cmd/rbmk
 
 #doc:
 #doc: - `check`: run tests
@@ -35,6 +35,6 @@ check:
 #doc: - `clean`: remove build artifacts
 .PHONY: clean
 clean:
-	rm -f rbmk rbmk-small
+	rm -f rbmk rbmk-lite
 
 #doc:


### PR DESCRIPTION
The new name seems more idiomatic for a version of rbmk built without supporting extra features (e.g., markdown rendering).