### PR TITLE
feat: print version info using `rbmk version`

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rbmk-project/rbmk/pkg/cli/tar"
 	"github.com/rbmk-project/rbmk/pkg/cli/timestamp"
 	"github.com/rbmk-project/rbmk/pkg/cli/tutorial"
+	"github.com/rbmk-project/rbmk/pkg/cli/version"
 )
 
 //go:embed README.md
@@ -46,5 +47,6 @@ func NewCommand() cliutils.Command {
 			"tar":       tar.NewCommand(),
 			"timestamp": timestamp.NewCommand(),
 			"tutorial":  tutorial.NewCommand(),
+			"version":   version.NewCommand(),
 		})
 }

--- a/pkg/cli/version/README.md
+++ b/pkg/cli/version/README.md
@@ -1,0 +1,22 @@
+
+# rbmk version - Print Version Information
+
+## Usage
+
+```
+rbmk version
+```
+
+## Description
+
+Prints on the stdout version information. We add version information
+when compiling `rbmk` using the `GNUMakefile`.
+
+Possible values for the version information are:
+
+- `dev` if we did not compile using the `GNUMakefile`.
+
+- `vX.Y.Z` if using `GNUMakefile` to build a specific tag.
+
+- `vX.Y.Z-<N>-g<SHA>` if using `GNUMakefile` to build
+a commit not associated with a tag.

--- a/pkg/cli/version/version.go
+++ b/pkg/cli/version/version.go
@@ -25,11 +25,13 @@ func NewCommand() cliutils.Command {
 
 type command struct{}
 
+// Help implements [cliutils.Command].
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
 	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 
+// Main implements [cliutils.Command].
 func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	// 1. honour requests for printing the help
 	if cliutils.HelpRequested(argv...) {

--- a/pkg/cli/version/version.go
+++ b/pkg/cli/version/version.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package version implements the `rbmk version` command.
+package version
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"github.com/rbmk-project/common/cliutils"
+	"github.com/rbmk-project/rbmk/internal/markdown"
+)
+
+// Version is the program version.
+var Version string = "dev"
+
+//go:embed README.md
+var readme string
+
+// NewCommand creates the `rbmk version` Command.
+func NewCommand() cliutils.Command {
+	return command{}
+}
+
+type command struct{}
+
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
+	return nil
+}
+
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
+	// 1. honour requests for printing the help
+	if cliutils.HelpRequested(argv...) {
+		return cmd.Help(env, argv...)
+	}
+
+	// 2. print the version
+	fmt.Fprintln(env.Stdout(), Version)
+	return nil
+}


### PR DESCRIPTION
Useful to know which version we're using (e.g., in bug reports).