### PR TITLE
fix(README.md): mention `nc` command in first sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 RBMK (Really Basic Measurement Kit) is a command-line utility
 to facilitate network exploration and measurements. It provides
-fundamental network operations (`dig`, `curl`, and `stun`) that you can
+fundamental network operations (`dig`, `curl`, `nc`, and `stun`) that you can
 compose together to perform modular network measurements where
 you can observe each operation in isolation.
 


### PR DESCRIPTION
As the diff title says, I noticed `nc` was not mentioned in the first sentence and I fixed it.