### PR TITLE
feat(ipuniq): implement --from-endpoint and --fail

### DIFF
--- a/pkg/cli/ipuniq/README.md
+++ b/pkg/cli/ipuniq/README.md
@@ -27,7 +27,25 @@ You enable random shuffling with `--random`. When not using `--random`, we
 stream unique addresses as soon as they are read. The streaming functionality
 was implemented in RBMK v0.4.0.
 
+The `-E, --from-endpoints` flag modifies the command behaviour to assume the
+input contains endpoints rather than just IP addresses (see below).
+
+Note that any input line that does not contain a valid IP address or
+endpoint is skipped and a warning is emitted.
+
 ## Flags
+
+### `-E, --from-endpoints`
+
+Assume that input already contains endpoints, that is `addr:port`, where
+the `addr` is an IP address, and there is `[` and `]` around IPv6
+addresses. Strip the port, and just retain the IP address for processing
+and emitting according to other `rbmk ipuniq` flags.
+
+### `-f, --fail`
+
+Cause the tool to fail (rather than emitting a warning) if an input
+line does not contain a valid IP address or endpoint (if `-E`).
 
 ### `-h, --help`
 
@@ -93,6 +111,16 @@ Create multiple endpoints for each IP addr:
 
 ```
 $ rbmk ipuniq --port 80 --port 443 ips.txt
+```
+
+### Filtering a list of endpoints
+
+Filter a list the endpoints and just keep IP addresses:
+
+```
+$ echo -e '10.0.0.1:80\n10.0.0.1:443\n127.0.0.1:111'| rbmk ipuniq -E
+10.0.0.1
+127.0.0.1
 ```
 
 ### Exit Status

--- a/pkg/cli/ipuniq/README.md
+++ b/pkg/cli/ipuniq/README.md
@@ -118,9 +118,16 @@ $ rbmk ipuniq --port 80 --port 443 ips.txt
 Filter a list the endpoints and just keep IP addresses:
 
 ```
-$ echo -e '10.0.0.1:80\n10.0.0.1:443\n127.0.0.1:111'| rbmk ipuniq -E
+$ echo -e '10.0.0.1:80\n10.0.0.1:443\n127.0.0.1:111' | rbmk ipuniq -E
 10.0.0.1
 127.0.0.1
+```
+
+Same but using IPv6 endpoints:
+
+```
+$ echo -e '[::1]:80\n[::1]:443' | rbmk ipuniq -E
+::1
 ```
 
 ### Exit Status

--- a/pkg/cli/ipuniq/ipuniq.go
+++ b/pkg/cli/ipuniq/ipuniq.go
@@ -44,7 +44,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 	ffail := clip.BoolP("fail", "f", false, "fail on input paesing error")
 	fports := clip.StringSliceP("port", "p", nil, "format output as HOST:PORT endpoints")
 	frand := clip.BoolP("random", "r", false, "randomly shuffle the output")
-	fromendpoints := clip.BoolP("from-endpoints", "E", false, "assume inputs contains endpoints")
+	fromendpoints := clip.BoolP("from-endpoints", "E", false, "assume input contains endpoints")
 
 	if err := clip.Parse(argv[1:]); err != nil {
 		fmt.Fprintf(env.Stderr(), "rbmk ipuniq: %s\n", err.Error())


### PR DESCRIPTION
The --from-endpoint flag causes ipuniq to parse endpoints.

Make explicit that we ignore invalid IP addresses or endpoints in input, by documenting it and emitting a warning.

Introduce --fail to fail instead of emitting a warning.