### PR TITLE
refactor: split build and release workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,4 @@
-# This workflow builds and tests a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
+# This workflow builds and tests rbmk Go code.
 name: Go
 
 on:
@@ -32,6 +30,3 @@ jobs:
 
       - name: Test
         run: make check
-
-      - name: Release
-        run: make release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+# This workflow cross-compile rbmk and (aspirationally for now)
+# publishes the binaries to the GitHub release page.
+#
+# TODO(bassosimone): implement publishing release artifacts. A key
+# aspect here is whether we want to sign them (which is a bit of
+# a burden both for macOS and Windows).
+name: Release
+
+on:
+  push:
+    # We generally run this workflow for tags but, for testing, it is
+    # possible to use branch bames starting with `fullbuild` or `release/`.
+    #
+    # Before a release, it is recommended to use either name to
+    # ensure that the release process is working as intended.
+    branches:
+      - "fullbuild*" # For quick release testing
+      - "release/*" # For proper release preparation
+    tags: ["v*"]
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        goversion:
+          # We should most likely only use the latest version of Go
+          # but I'm keeping the matrix for flexibility
+          - "1.23"
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "${{ matrix.goversion }}"
+
+      - name: Release
+        run: make release


### PR DESCRIPTION
The `go.yml` workflow checks whether we can build and whether tests are running, and runs for every PR and merge.

The `release.yml` workflow handles cross-compilation checks and will support artifact publishing in the future.

This split follows the single responsibility principle and reduces PR build times by deferring release builds.