### PR TITLE
fix(sh): allow passing CLI arguments to scripts

### DIFF
--- a/pkg/cli/sh/README.md
+++ b/pkg/cli/sh/README.md
@@ -4,12 +4,14 @@
 ## Usage
 
 ```
-rbmk sh SCRIPT
+rbmk sh SCRIPT [ARGUMENTS...]
 ```
 
 ## Description
 
-Run SCRIPT using a POSIX-compliant shell interpreter.
+Run `SCRIPT` using a POSIX-compliant shell interpreter providing
+to the script the given `ARGUMENTS`, which will be available to
+the script as `$1`, `$2`, etc.
 
 This shell implementation (based on `mvdan.cc/sh/v3`) is consistent
 across operating systems and supports:
@@ -23,7 +25,6 @@ across operating systems and supports:
 - Loops and conditionals
 
 - Environment variables
-
 
 ## Available Commands
 
@@ -85,9 +86,14 @@ This command exits with `0` on success and `1` on failure.
 
 ## History
 
+Since RBMK v0.10.0, it is possible to pass arguments to the script
+executed by `rbmk sh` using the command line.
+
 Before RBMK v0.7.0, `rbmk sh` used to set the `$RBMK_EXE` environment
-variable to its path, to allow a script to execute `rbmk` commands.
+variable to the `rbmk` path, to allow a script to execute `rbmk` commands.
 
 Since v0.7.0. `rbmk` is an internal shell command, `rbmk sh` is not capable
 of executing external commands, and `$RBMK_EXE` is set to `rbmk`, thus
 supporting previously existing scripts without modification.
+
+The `rbmk sh` command appeared in RBMK v0.2.0.

--- a/pkg/cli/sh/sh.go
+++ b/pkg/cli/sh/sh.go
@@ -39,8 +39,8 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 	}
 
 	// 2. Ensure we have exactly one script to run.
-	if len(argv) != 2 {
-		err := errors.New("expected exactly one script argument")
+	if len(argv) < 2 {
+		err := errors.New("expected a script with optional arguments")
 		fmt.Fprintf(env.Stderr(), "rbmk sh: %s\n", err.Error())
 		fmt.Fprintf(env.Stderr(), "Run `rbmk sh --help` for usage.\n")
 		return err
@@ -71,6 +71,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 		interp.StdIO(env.Stdin(), env.Stdout(), env.Stderr()),
 		interp.Env(expand.FuncEnviron(os.Getenv)),
 		interp.ExecHandlers(newBuiltInMiddleware()),
+		interp.Params(argv[2:]...),
 	)
 	if err != nil {
 		fmt.Fprintf(env.Stderr(), "rbmk sh: cannot create interpreter: %s\n", err.Error())


### PR DESCRIPTION
This diff fixes a limitation of `rbmk sh`, that is, the fact that we cannot provide arguments to shell scripts.