### PR TITLE
fix(stun): the flag is --max-time not --maxtime

### DIFF
--- a/pkg/cli/stun/stun.go
+++ b/pkg/cli/stun/stun.go
@@ -52,7 +52,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 
 	// 4. add flags to the parser
 	logfile := clip.String("logs", "", "path where to write structured logs")
-	maxtime := clip.Int("maxtime", 30, "maximum time for transaction to complete (in seconds)")
+	maxtime := clip.Int("max-time", 30, "maximum time for transaction to complete (in seconds)")
 	measure := clip.Bool("measure", false, "do not exit 1 on measurement failure")
 
 	// 5. parse command line arguments


### PR DESCRIPTION
This commit fixes a defect in the `rbmk stun` command where the `--max-time DURATION` flag was incorrectly parsed as `--maxtime` by the command line flags parsing code. I don't consider this change a breaking change given that the flag was clearly and correctly documented as `--max-time` by `rbmk stun --help`.