### PR TITLE
feat(nc): implement the `-T, --option` flag

### DIFF
--- a/pkg/cli/intro/intro.go
+++ b/pkg/cli/intro/intro.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+// Package intro implements the `rbmk intro` Command.
 package intro
 
 import (
@@ -21,10 +22,12 @@ func NewCommand() cliutils.Command {
 
 type command struct{}
 
+// Help implements [cliutils.Command].
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
 	return cmd.Main(context.Background(), env, argv...)
 }
 
+// Main implements [cliutils.Command].
 func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil

--- a/pkg/cli/nc/README.md
+++ b/pkg/cli/nc/README.md
@@ -64,6 +64,18 @@ handshake. For example:
 
 Must be used alongside the `--tls` flag.
 
+### `-T, --option OPTION`
+
+Set a specific `OPTION`. Can be specified multiple times to provide
+multiple options. We currently accept the following options:
+
+- `noverify` (added in RBMK v0.11.0): Do not verify the server's
+certificate, which is useful for measuring SNI-based blocking using
+arbitrary TLS endpoints as test helpers. This option only takes
+effect when combined with the `-c, --tls` flag.
+
+The `-T` flag was introduced in RBMK v0.11.0.
+
 ### `-v`
 
 Print more verbose output.
@@ -103,6 +115,13 @@ Same as above but also perform a TLS handshake:
 
 ```
 $ rbmk nc --alpn h2 --alpn http/1.1 -z -c -w5 example.com 443
+```
+
+Checking for SNI based blocking:
+
+```
+$ rbmk nc -zcw5 --alpn h2 --alpn http/1.1 -T noverify \
+    --sni x.com example.com 443
 ```
 
 Saving structured logs:

--- a/pkg/cli/nc/nc.go
+++ b/pkg/cli/nc/nc.go
@@ -51,6 +51,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 
 	// Additional TLS features
 	alpn := clip.StringSlice("alpn", nil, "TLS ALPN protocol(s)")
+	options := clip.StringSliceP("option", "T", []string{}, "TLS options")
 	sni := clip.String("sni", "", "TLS SNI server name")
 
 	// RBMK specific flags
@@ -84,6 +85,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 		Stderr:        io.Discard,
 		Stdin:         env.Stdin(),
 		Stdout:        env.Stdout(),
+		TLSNoVerify:   false,
 		UseTLS:        *useTLS,
 		WaitTimeout:   0,
 	}
@@ -97,6 +99,12 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 	}
 	if *verbose {
 		task.Stderr = env.Stderr()
+	}
+	for _, opt := range *options {
+		switch opt {
+		case "noverify":
+			task.TLSNoVerify = true
+		}
 	}
 
 	// 6. handle logs flag

--- a/pkg/cli/nc/task.go
+++ b/pkg/cli/nc/task.go
@@ -50,6 +50,9 @@ type Task struct {
 	// Stdout is the MANDATORY [io.Writer] for the stdout.
 	Stdout io.Writer
 
+	// TLSNoVerify is a flag that disables TLS verification.
+	TLSNoVerify bool
+
 	// UseTLS is a flag that ensures that we use TLS.
 	UseTLS bool
 
@@ -70,9 +73,10 @@ func (task *Task) Run(ctx context.Context) error {
 	netx := &netcore.Network{}
 	netx.DialContextFunc = testable.DialContext.Get()
 	netx.TLSConfig = &tls.Config{
-		NextProtos: task.ALPNProtocols,
-		RootCAs:    testable.RootCAs.Get(),
-		ServerName: task.ServerName,
+		InsecureSkipVerify: task.TLSNoVerify,
+		NextProtos:         task.ALPNProtocols,
+		RootCAs:            testable.RootCAs.Get(),
+		ServerName:         task.ServerName,
 	}
 	netx.Logger = logger
 	netx.WrapConn = func(ctx context.Context, netx *netcore.Network, conn net.Conn) net.Conn {


### PR DESCRIPTION
The `-T` short flag is compatible with OpenBSD nc(1) and allows to specify the `noverify` option to skip TLS verification.

In turn, skipping TLS verification is needed to avoid errors or warnings (depending on `--measure`) when using `rbmk nc` to check for SNI based blocking using arbitrary remote TLS servers as the test servers (e.g., using `www.example.com:443` to check whether a rule in the network blocks the `www.instagram.com` SNI).

Strictly speaking, we don't need this flag since the test is okay also with verification enabled. Additionally, one can say that expecting a verification error is actually the expected state and disabling verification could miss a MITM. That said, consider also that a test such as SNI blocking depends on the assumptions you make. If you assume that MITM is not a concern, then it leads to nicer UX which avoids emitting any error. Also, do not miss the fact that TLS MITM could still be detected when post-processing the measurement results.

While there, add missing documentation comments to intro.go.