### PR TITLE
doc(nc): document known ^C limitation

### DIFF
--- a/pkg/cli/nc/README.md
+++ b/pkg/cli/nc/README.md
@@ -130,6 +130,14 @@ Saving structured logs:
 $ rbmk nc --logs conn.jsonl example.com 80
 ```
 
+## Bugs
+
+When running a command such as:
+
+```
+$ rbmk nc example.com 80
+```
+
 ## Exit Status
 
 The nc utility exits with `0` on success and `1` on error.

--- a/pkg/cli/nc/README.md
+++ b/pkg/cli/nc/README.md
@@ -138,6 +138,11 @@ When running a command such as:
 $ rbmk nc example.com 80
 ```
 
+we keep the `stdin` in line-oriented mode, which allows to send
+protocol data on a line-by-line basis. However, this also implies
+that `^C` does not interrupt reading from the `stdin`, because
+the terminal driver is blocked reading until the EOL.
+
 ## Exit Status
 
 The nc utility exits with `0` on success and `1` on error.


### PR DESCRIPTION
I tried improving the situation but this means making the terminal raw, which makes it more complex to manually type protocols. So, for now, I am settling to just document this as a known bug.