### PR TITLE
feat: implement the `rbmk head` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ rbmk curl https://example.com/
 ...
 
 # Combine dig and curl for step-by-step measurement
-$ IP=$(rbmk dig +short=ip example.com|head -n1)
+$ IP=$(rbmk dig +short=ip example.com | rbmk head -n 1)
 $ rbmk curl --resolve example.com:443:$IP https://example.com/
 
 # Collect measurement data in flat JSONL format
@@ -132,6 +132,7 @@ Core Measurement Commands:
 
 Unix-like Commands for Scripting:
 - `cat`: Concatenates files.
+- `head`: Print first lines of files.
 - `ipuniq`: Shuffle, deduplicate, and format IP addresses.
 - `mkdir`: Creates directories.
 - `mv`: Moves (renames) files and directories.

--- a/internal/rootcmd/README.md
+++ b/internal/rootcmd/README.md
@@ -22,6 +22,7 @@ to facilitate network exploration and measurements.
 ### Unix-like Commands for Scripting
 
 * `cat` - Concatenates files to standard output.
+* `head` - Print first lines of files.
 * `ipuniq` - Shuffle, deduplicate, and format IP addresses.
 * `mkdir` - Creates directories.
 * `mv` - Moves (renames) files and directories.

--- a/internal/rootcmd/rootcmd.go
+++ b/internal/rootcmd/rootcmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rbmk-project/rbmk/pkg/cli/cat"
 	"github.com/rbmk-project/rbmk/pkg/cli/curl"
 	"github.com/rbmk-project/rbmk/pkg/cli/dig"
+	"github.com/rbmk-project/rbmk/pkg/cli/head"
 	"github.com/rbmk-project/rbmk/pkg/cli/intro"
 	"github.com/rbmk-project/rbmk/pkg/cli/ipuniq"
 	"github.com/rbmk-project/rbmk/pkg/cli/mkdir"
@@ -61,6 +62,7 @@ func CommandsWithoutSh() map[string]cliutils.Command {
 		"cat":       cat.NewCommand(),
 		"curl":      curl.NewCommand(),
 		"dig":       dig.NewCommand(),
+		"head":      head.NewCommand(),
 		"intro":     intro.NewCommand(),
 		"ipuniq":    ipuniq.NewCommand(),
 		"mkdir":     mkdir.NewCommand(),

--- a/pkg/cli/head/README.md
+++ b/pkg/cli/head/README.md
@@ -1,0 +1,75 @@
+
+# rbmk head - Print First Lines
+
+## Usage
+
+```
+rbmk head [-n COUNT] [FILE...]
+```
+
+## Description
+
+Print the first `COUNT` lines of each `FILE` to the standard
+output. With no specified `FILE`, or when the `FILE` is `-`, read
+the standard input.
+
+## Flags
+
+### `-h, --help`
+
+Print this help message.
+
+### `-n, --lines COUNT`
+
+Print the first `COUNT` lines instead of the first 10. The
+`COUNT` must be a non-negative integer.
+
+## Examples
+
+Print first 10 lines from stdin:
+
+```
+$ rbmk dig +short=ip example.com | rbmk head
+```
+
+Print first 2 lines from stdin:
+
+```
+$ rbmk dig +short=ip example.com | rbmk head -n 2
+```
+
+Print first 5 lines from multiple files:
+
+```
+$ rbmk head -n 5 file1.txt file2.txt
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## Bugs
+
+When running a command such as:
+
+```
+$ rbmk head
+```
+
+we keep the `stdin` in line-oriented mode, which means that you
+can edit the input before pressing enter. However, this also implies
+that `^C` does not interrupt reading from the `stdin`, because
+the terminal driver is blocked reading until the EOL. The symptom
+of this would be:
+
+```
+$ rbmk head
+^C
+```
+
+where the program does not exit. To exit, insert an explicit
+EOL character (e.g., `^D` on Unix and `^Z` + `Return` on Windows).
+
+## History
+
+The `rbmk head` command was introduced in RBMK v0.11.0.

--- a/pkg/cli/head/head.go
+++ b/pkg/cli/head/head.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package head implements the `rbmk head` command.
+package head
+
+import (
+	"bufio"
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+
+	"github.com/rbmk-project/common/cliutils"
+	"github.com/rbmk-project/rbmk/internal/markdown"
+	"github.com/spf13/pflag"
+)
+
+//go:embed README.md
+var readme string
+
+// NewCommand creates the `rbmk head` Command.
+func NewCommand() cliutils.Command {
+	return command{}
+}
+
+type command struct{}
+
+// Help implements [cliutils.Command].
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
+	return nil
+}
+
+// Main implements [cliutils.Command].
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
+	// 1. honour requests for printing the help
+	if cliutils.HelpRequested(argv...) {
+		return cmd.Help(env, argv...)
+	}
+
+	// 2. parse command line flags
+	clip := pflag.NewFlagSet("rbmk head", pflag.ContinueOnError)
+	lines := clip.UintP("lines", "n", 10, "number of lines to print")
+
+	if err := clip.Parse(argv[1:]); err != nil {
+		fmt.Fprintf(env.Stderr(), "rbmk head: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk head --help` for usage.\n")
+		return err
+	}
+
+	// 4. collect the files to read from, if any. Otherwise,
+	// we will read from the standard input.
+	args := clip.Args()
+	if len(args) <= 0 {
+		args = append(args, "-")
+	}
+
+	// 5. read from each file
+	for _, fname := range args {
+		if err := readHead(env, fname, *lines); err != nil {
+			fmt.Fprintf(env.Stderr(), "rbmk head: %s\n", err.Error())
+			return err
+		}
+	}
+	return nil
+}
+
+// readHead reads up to count lines from the given file and prints them
+// to stdout. The special filename "-" means read from stdin.
+func readHead(env cliutils.Environment, fname string, count uint) error {
+	var reader io.Reader
+	if fname != "-" {
+		filep, err := env.FS().Open(fname)
+		if err != nil {
+			return err
+		}
+		defer filep.Close()
+		reader = filep
+	} else {
+		reader = env.Stdin()
+	}
+
+	scanner := bufio.NewScanner(reader)
+	for linenum := uint(0); linenum < count && scanner.Scan(); linenum++ {
+		fmt.Fprintln(env.Stdout(), scanner.Text())
+	}
+	return scanner.Err()
+}

--- a/pkg/cli/head/head.go
+++ b/pkg/cli/head/head.go
@@ -48,14 +48,14 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 		return err
 	}
 
-	// 4. collect the files to read from, if any. Otherwise,
+	// 3. collect the files to read from, if any. Otherwise,
 	// we will read from the standard input.
 	args := clip.Args()
 	if len(args) <= 0 {
 		args = append(args, "-")
 	}
 
-	// 5. read from each file
+	// 4. read from each file
 	for _, fname := range args {
 		if err := readHead(env, fname, *lines); err != nil {
 			fmt.Fprintf(env.Stderr(), "rbmk head: %s\n", err.Error())

--- a/pkg/cli/intro/README.md
+++ b/pkg/cli/intro/README.md
@@ -39,7 +39,7 @@ $ rbmk curl --resolve example.com:443:93.184.215.14 https://example.com/
 Separate DNS and HTTP measurements:
 
 ```
-$ IP=$(rbmk dig +short=ip example.com|head -n1)
+$ IP=$(rbmk dig +short=ip example.com | rbmk head -n1)
 $ rbmk curl --resolve example.com:443:$IP https://example.com/
 ```
 

--- a/pkg/cli/ipuniq/README.md
+++ b/pkg/cli/ipuniq/README.md
@@ -134,6 +134,28 @@ $ echo -e '[::1]:80\n[::1]:443' | rbmk ipuniq -E
 
 This command exits with `0` on success and `1` on failure.
 
+## Bugs
+
+When running a command such as:
+
+```
+$ rbmk ipuniq
+```
+
+we keep the `stdin` in line-oriented mode, which means that you
+can edit the input before pressing enter. However, this also implies
+that `^C` does not interrupt reading from the `stdin`, because
+the terminal driver is blocked reading until the EOL. The symptom
+of this would be:
+
+```
+$ rbmk ipuniq
+^C
+```
+
+where the program does not exit. To exit, insert an explicit
+EOL character (e.g., `^D` on Unix and `^Z` + `Return` on Windows).
+
 ### History
 
 Before RBMK v0.4.0, this command always randomly shuffled the

--- a/pkg/cli/nc/README.md
+++ b/pkg/cli/nc/README.md
@@ -130,6 +130,10 @@ Saving structured logs:
 $ rbmk nc --logs conn.jsonl example.com 80
 ```
 
+## Exit Status
+
+The nc utility exits with `0` on success and `1` on error.
+
 ## Bugs
 
 When running a command such as:
@@ -141,11 +145,16 @@ $ rbmk nc example.com 80
 we keep the `stdin` in line-oriented mode, which allows to send
 protocol data on a line-by-line basis. However, this also implies
 that `^C` does not interrupt reading from the `stdin`, because
-the terminal driver is blocked reading until the EOL.
+the terminal driver is blocked reading until the EOL. The symptom
+of this would be:
 
-## Exit Status
+```
+$ rbmk nc example.com 80
+^C
+```
 
-The nc utility exits with `0` on success and `1` on error.
+where the program does not exit. To exit, insert an explicit
+EOL character (e.g., `^D` on Unix and `^Z` + `Return` on Windows).
 
 ## History
 

--- a/pkg/cli/tutorial/basics.md
+++ b/pkg/cli/tutorial/basics.md
@@ -74,7 +74,7 @@ $ rbmk nc --alpn h2 --alpn http/1.1 -zvc example.com 443
 Commands can be combined to perform detailed measurements:
 
 ```
-$ ip=$(rbmk dig +short=ip example.com | head -n1)
+$ ip=$(rbmk dig +short=ip example.com | rbmk head -n1)
 $ rbmk curl --resolve "example.com:443:$ip" https://example.com/
 ```
 


### PR DESCRIPTION
I noticed that some tutorials suggested `... | head -n1` but then I guess it's more practical to implement `rbmk head` and allow using this command also on Windows.

Consistently, update tutorials to refer to `rbmk head`.

Also, notice we could improve the wording of programs being blocked reading on line-oriented `stdin` (currently, `nc`, `head`, and `ipuniq`) and apply changes for each of them.

Xref: https://github.com/rbmk-project/rbmk-project.github.io/pull/17