### PR TITLE
feat: implement `rbmk random` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
 /*.exe
+/*.tar.gz
+/202*
 /rbmk
 /rbmk-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 /*.exe
 /*.tar.gz
-/202*
 /rbmk
 /rbmk-*

--- a/README.md
+++ b/README.md
@@ -135,10 +135,13 @@ Unix-like Commands for Scripting:
 - `ipuniq`: Shuffle, deduplicate, and format IP addresses.
 - `mkdir`: Creates directories.
 - `mv`: Moves (renames) files and directories.
+- `pipe`: Creates named pipes for inter-process communication.
+- `random`: Generates random bytes.
 - `rm`: Removes files and directories.
 - `sh`: Runs POSIX shell scripts.
 - `tar`: Creates tar archives.
 - `timestamp`: Prints filesystem-friendly timestamps.
+- `version`: Prints the `rbmk` version.
 
 Helper Commands:
 - `intro`: Shows a brief introduction with usage examples.

--- a/internal/rootcmd/README.md
+++ b/internal/rootcmd/README.md
@@ -27,6 +27,7 @@ to facilitate network exploration and measurements.
 * `mkdir` - Creates directories.
 * `mv` - Moves (renames) files and directories.
 * `pipe` - Creates named pipes for inter-process communication.
+* `random` - Generates random bytes.
 * `rm` - Removes files and directories.
 * `sh` - Runs POSIX shell scripts.
 * `tar` - Creates tar archives.

--- a/internal/rootcmd/rootcmd.go
+++ b/internal/rootcmd/rootcmd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/rbmk-project/rbmk/pkg/cli/mv"
 	"github.com/rbmk-project/rbmk/pkg/cli/nc"
 	"github.com/rbmk-project/rbmk/pkg/cli/pipe"
+	"github.com/rbmk-project/rbmk/pkg/cli/random"
 	"github.com/rbmk-project/rbmk/pkg/cli/rm"
 	"github.com/rbmk-project/rbmk/pkg/cli/stun"
 	"github.com/rbmk-project/rbmk/pkg/cli/tar"
@@ -69,6 +70,7 @@ func CommandsWithoutSh() map[string]cliutils.Command {
 		"mv":        mv.NewCommand(),
 		"nc":        nc.NewCommand(),
 		"pipe":      pipe.NewCommand(),
+		"random":    random.NewCommand(),
 		"rm":        rm.NewCommand(),
 		"stun":      stun.NewCommand(),
 		"tar":       tar.NewCommand(),

--- a/pkg/cli/pipe/README.md
+++ b/pkg/cli/pipe/README.md
@@ -90,7 +90,8 @@ To mitigate this issue, use paths relative to the current working
 directory in your scripts and attemp to keep them short. Specifically,
 you can create a unique directory for measuring with a short name,
 using `rbmk timestamp --full` to generate a timestamp-based name with
-nanosecond precision. Then, once the measurement is complete, you
+nanosecond precision and possibly combining it with `rbmk random` to
+add additional entropy. Then, once the measurement is complete, you
 can move the results to a longer, more logical path name.
 
 ## History

--- a/pkg/cli/random/README.md
+++ b/pkg/cli/random/README.md
@@ -1,0 +1,47 @@
+
+# rbmk random - Random Bytes Generation
+
+## Usage
+
+```
+rbmk random [flags]
+```
+
+## Description
+
+Generate random bytes using a cryptographically secure random number
+generator and print them as hexadecimal to stdout.
+
+## Flags
+
+### `-h, --help`
+
+Print this help message.
+
+### `--bytes COUNT`
+
+Number of random bytes to generate. The default is 4 bytes.
+
+## Examples
+
+Generate 4 random bytes (default):
+
+```
+$ rbmk random
+a1b2c3d4
+```
+
+Generate 16 random bytes:
+
+```
+$ rbmk random --bytes 16
+a1b2c3d4e5f6789012345678deadbeef
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## History
+
+The `rbmk random` command was introduced in RBMK v0.12.0.

--- a/pkg/cli/random/random.go
+++ b/pkg/cli/random/random.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package random implements the `rbmk random` command.
+package random
+
+import (
+	"context"
+	"crypto/rand"
+	_ "embed"
+	"errors"
+	"fmt"
+
+	"github.com/rbmk-project/common/cliutils"
+	"github.com/rbmk-project/rbmk/internal/markdown"
+	"github.com/spf13/pflag"
+)
+
+//go:embed README.md
+var readme string
+
+// NewCommand creates the `rbmk random` Command.
+func NewCommand() cliutils.Command {
+	return command{}
+}
+
+type command struct{}
+
+// Help implements [cliutils.Command].
+func (cmd command) Help(env cliutils.Environment, argv ...string) error {
+	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
+	return nil
+}
+
+// Main implements [cliutils.Command].
+func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
+	// 1. honour requests for printing the help
+	if cliutils.HelpRequested(argv...) {
+		return cmd.Help(env, argv...)
+	}
+
+	// 2. parse command line flags
+	clip := pflag.NewFlagSet("rbmk random", pflag.ContinueOnError)
+	nbytes := clip.Uint("bytes", 4, "number of random bytes to generate")
+
+	if err := clip.Parse(argv[1:]); err != nil {
+		fmt.Fprintf(env.Stderr(), "rbmk random: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk random --help` for usage.\n")
+		return err
+	}
+
+	// 3. ensure we have no positional arguments
+	args := clip.Args()
+	if len(args) != 0 {
+		err := errors.New("expected zero positional arguments")
+		fmt.Fprintf(env.Stderr(), "rbmk random: %s\n", err.Error())
+		fmt.Fprintf(env.Stderr(), "Run `rbmk random --help` for usage.\n")
+		return err
+	}
+
+	// 4. generate the random bytes
+	buf := make([]byte, *nbytes)
+	if _, err := rand.Read(buf); err != nil {
+		fmt.Fprintf(env.Stderr(), "rbmk random: %s\n", err.Error())
+		return err
+	}
+
+	// 5. output as hex
+	fmt.Fprintf(env.Stdout(), "%x\n", buf)
+	return nil
+}

--- a/pkg/cli/rm/rm.go
+++ b/pkg/cli/rm/rm.go
@@ -25,11 +25,13 @@ func NewCommand() cliutils.Command {
 
 type command struct{}
 
+// Help implements [cliutils.Command].
 func (cmd command) Help(env cliutils.Environment, argv ...string) error {
 	fmt.Fprintf(env.Stdout(), "%s\n", markdown.MaybeRender(readme))
 	return nil
 }
 
+// Main implements [cliutils.Command].
 func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...string) error {
 	// 1. honour requests for printing the help
 	if cliutils.HelpRequested(argv...) {

--- a/pkg/cli/sh/README.md
+++ b/pkg/cli/sh/README.md
@@ -65,12 +65,11 @@ First, let's see the content of the the `script.bash` file:
 ```sh
 #!/bin/bash
 set -x
-timestamp=$(rbmk timestamp)
-outdir="$timestamp"
+outdir="$(rbmk timestamp --full)-$(rbmk random)"
 rbmk mkdir -p "$outdir"
 rbmk dig +short=ip A "dns.google" > "$outdir/dig1.txt"
 rbmk dig +short=ip AAAA "dns.google" > "$outdir/dig2.txt"
-rbmk tar -czf "results_$timestamp.tar.gz" "$outdir"
+rbmk tar -czf "results_$outdir.tar.gz" "$outdir"
 rbmk rm -rf "$outdir"
 ```
 


### PR DESCRIPTION
This command helps to generate unique directory names.

The default is to emit 4 bytes of entropy.

While there, add `*.tar.gz` (i.e., compressed measurements) to the `.gitignore`.

While there, add missing commands to `README.md`.

While there, add missing documentation comments to `rm.go`.