### PR TITLE
feat(cat): implement reading from the stdin

### DIFF
--- a/pkg/cli/cat/README.md
+++ b/pkg/cli/cat/README.md
@@ -4,12 +4,14 @@
 ## Usage
 
 ```
-rbmk cat FILE...
+rbmk cat [FILE...]
 ```
 
 ## Description
 
-Concatenate files and print on the standard output.
+Concatenate files and print on the standard output. If no `FILE`
+is specified, read from the standard input. If `FILE` is `-`,
+read from the standard input.
 
 ## Examples
 
@@ -25,5 +27,8 @@ $ rbmk cat file1.txt file2.txt
 This command exits with `0` on success and `1` on failure.
 
 ## History
+
+Support from reading from the standard input and for treating
+`-` as the standard input was introduced in RBMK v0.12.0.
 
 The `rbmk cat` command was introduced in RBMK v0.2.0.


### PR DESCRIPTION
This is what the real `cat` command does and it is useful when writing shell scripts (e.g., `rbmk cat << EOF`).