### PR TITLE
fix(version): properly validate command line arguments

### DIFF
--- a/pkg/cli/version/version.go
+++ b/pkg/cli/version/version.go
@@ -38,7 +38,15 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 		return cmd.Help(env, argv...)
 	}
 
-	// 2. print the version
+	// 2. ensure there are no command line arguments
+	if len(argv) > 1 {
+		err := fmt.Errorf("expected no positional arguments")
+		fmt.Fprintf(env.Stderr(), "rbmk version: %s\n", err)
+		fmt.Fprintf(env.Stderr(), "Run `rbmk version --help` for usage.\n")
+		return err
+	}
+
+	// 3. print the version
 	fmt.Fprintln(env.Stdout(), Version)
 	return nil
 }


### PR DESCRIPTION
Exit with diagnostic message and code 1 if there are command line arguments. Doing this just for correctness.