### PR TITLE
fix(sh): avoid os.Setenv / os.Getenv race

### DIFF
--- a/pkg/cli/sh/sh.go
+++ b/pkg/cli/sh/sh.go
@@ -62,22 +62,12 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 		return err
 	}
 
-	// 4. Ensure the RBMK_EXE environment variable is set to support
-	// scripts written before the release of RBMK v0.7.0.
-	//
-	// Note: os.Setenv is NOT THREAD SAFE in Go. At present it's unclear
-	// whether this os.Setenv has any implication, but we should keep this
-	// in mind in case we see strange crashes in the future.
-	//
-	// See: https://www.edgedb.com/blog/c-stdlib-isn-t-threadsafe-and-even-safe-rust-didn-t-save-us
-	os.Setenv("RBMK_EXE", "rbmk")
-
-	// 5. Create the shell interpreter ensuring we properly use `--` to
+	// 4. Create the shell interpreter ensuring we properly use `--` to
 	// ensure options get passed to the script itself.
 	scriptParams := append([]string{"--"}, argv[2:]...)
 	runner, err := interp.New(
 		interp.StdIO(env.Stdin(), env.Stdout(), env.Stderr()),
-		interp.Env(expand.FuncEnviron(os.Getenv)),
+		interp.Env(expand.FuncEnviron(osGetenvWrapper)),
 		interp.ExecHandlers(newBuiltInMiddleware()),
 		interp.Params(scriptParams...),
 	)
@@ -86,11 +76,29 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 		return err
 	}
 
-	// 6. Finally, run the shell script.
+	// 5. Finally, run the shell script.
 	err = runner.Run(ctx, prog)
 	if err != nil {
 		fmt.Fprintf(env.Stderr(), "rbmk sh: %s\n", err.Error())
 		return err
 	}
 	return nil
+}
+
+// osGetenvWrapper is a wrapper for [os.Getenv] that ensures that the
+// RBMK_EXE environment variable is set to support scripts written
+// before the release of RBMK v0.7.0.
+//
+// We use a wrapper rather than setting the environment explicitly
+// because [os.Setenv] is NOT THREAD SAFE in Go. Thus, it seems more
+// robust to avoid using it and potentially racing between it and
+// [os.Getenv], used by the shell interpreter.
+//
+// See: https://www.edgedb.com/blog/c-stdlib-isn-t-threadsafe-and-even-safe-rust-didn-t-save-us
+func osGetenvWrapper(key string) string {
+	value := os.Getenv(key)
+	if value == "" && key == "RBMK_EXE" {
+		value = "rbmk"
+	}
+	return value
 }

--- a/pkg/cli/sh/sh.go
+++ b/pkg/cli/sh/sh.go
@@ -85,6 +85,10 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 	return nil
 }
 
+// rbmkExeVarName is the name of the RBMK_EXE environment variable,
+// which is shared by this package and its unit tests.
+const rbmkExeVarName = "RBMK_EXE"
+
 // osGetenvWrapper is a wrapper for [os.Getenv] that ensures that the
 // RBMK_EXE environment variable is set to support scripts written
 // before the release of RBMK v0.7.0.
@@ -97,7 +101,7 @@ func (cmd command) Main(ctx context.Context, env cliutils.Environment, argv ...s
 // See: https://www.edgedb.com/blog/c-stdlib-isn-t-threadsafe-and-even-safe-rust-didn-t-save-us
 func osGetenvWrapper(key string) string {
 	value := os.Getenv(key)
-	if value == "" && key == "RBMK_EXE" {
+	if value == "" && key == rbmkExeVarName {
 		value = "rbmk"
 	}
 	return value

--- a/pkg/cli/sh/sh_test.go
+++ b/pkg/cli/sh/sh_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package sh
+
+import (
+	"os"
+	"testing"
+)
+
+// Ensure that `$RBMK_EXE` expands to `rbmk` in the common case.
+func Test_osGetenvWrapper(t *testing.T) {
+	// Make sure the variable is not set already
+	const varname = "RBMK_EXE"
+	if os.Getenv(varname) != "" {
+		t.Skip("the environment variable is already set")
+	}
+
+	// Check whether we get the expected value (yes, there is a race
+	// with a potential os.Setenv in this test but we're not going
+	// to call os.Setenv here so we're good).
+	if value := osGetenvWrapper(varname); value != "rbmk" {
+		t.Error("unexpected value", value)
+	}
+}

--- a/pkg/cli/sh/sh_test.go
+++ b/pkg/cli/sh/sh_test.go
@@ -10,15 +10,14 @@ import (
 // Ensure that `$RBMK_EXE` expands to `rbmk` in the common case.
 func Test_osGetenvWrapper(t *testing.T) {
 	// Make sure the variable is not set already
-	const varname = "RBMK_EXE"
-	if os.Getenv(varname) != "" {
+	if os.Getenv(rbmkExeVarName) != "" {
 		t.Skip("the environment variable is already set")
 	}
 
 	// Check whether we get the expected value (yes, there is a race
 	// with a potential os.Setenv in this test but we're not going
 	// to call os.Setenv here so we're good).
-	if value := osGetenvWrapper(varname); value != "rbmk" {
+	if value := osGetenvWrapper(rbmkExeVarName); value != "rbmk" {
 		t.Error("unexpected value", value)
 	}
 }


### PR DESCRIPTION
This would possibly be just a correctness change. I have a vague recollection of a single crash that occurred long time ago and I am not sure this may be the reason. In any case, since there's a potential race, let's just avoid racing.