### PR TITLE
doc: automatically copy manpages

### DIFF
--- a/.github/workflows/copyman.yml
+++ b/.github/workflows/copyman.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check for Stale Manual Pages
-        run: ./script/copyman.bash --fail-if-dirty
+        run: ./scripts/copyman.bash --fail-if-dirty

--- a/.github/workflows/copyman.yml
+++ b/.github/workflows/copyman.yml
@@ -1,0 +1,18 @@
+# This workflow ensures copied manual pages aren't stale
+
+name: CopyMan
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for Stale Manual Pages
+        run: ./script/copyman.bash --fail-if-dirty

--- a/README.md
+++ b/README.md
@@ -113,10 +113,6 @@ Run `make` without arguments to see all available targets.
 
 Read the packages documentation at [pkg.go.dev/rbmk-project/rbmk](https://pkg.go.dev/github.com/rbmk-project/rbmk).
 
-## Design
-
-The [docs/design](./docs/design) directory contains all the design documents.
-
 ## Architecture
 
 **Documentation:**

--- a/docs/man/rbmk-cat.md
+++ b/docs/man/rbmk-cat.md
@@ -1,0 +1,34 @@
+
+# rbmk cat - File Concatenation
+
+## Usage
+
+```
+rbmk cat [FILE...]
+```
+
+## Description
+
+Concatenate files and print on the standard output. If no `FILE`
+is specified, read from the standard input. If `FILE` is `-`,
+read from the standard input.
+
+## Examples
+
+The following invocation concatenates the content of the
+`file1.txt` and `file2.txt` files to the stdout:
+
+```
+$ rbmk cat file1.txt file2.txt
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## History
+
+Support from reading from the standard input and for treating
+`-` as the standard input was introduced in RBMK v0.12.0.
+
+The `rbmk cat` command was introduced in RBMK v0.2.0.

--- a/docs/man/rbmk-curl.md
+++ b/docs/man/rbmk-curl.md
@@ -1,0 +1,107 @@
+
+# rbmk curl - HTTP Measurements
+
+## Usage
+
+```
+rbmk curl [flags] URL
+```
+
+## Description
+
+A subset of `curl(1)` functionality focused on network measurements. We only
+support measuring `http://` and `https://` URLs.
+
+## Flags
+
+### `-h, --help`
+
+Print this help message.
+
+### `--logs FILE`
+
+Writes structured logs to the given `FILE`. If `FILE` already exists, we
+append to it. If `FILE` does not exist, we create it. If `FILE` is a single
+dash (`-`), we write to the stdout. If you specify `--logs` multiple
+times, we write to the last `FILE` specified.
+
+### `--max-time DURATION`
+
+Sets the maximum time that the transfer operation is allowed to take
+in seconds (e.g., `--max-time 5`). If this flag is not specified, the
+default max time is 30 seconds.
+
+### `--measure`
+
+Do not exit with `1` if communication with the server fails. Only exit
+with `1` in case of usage errors, or failure to process inputs. You should
+use this flag inside measurement scripts along with `set -e`. Errors are
+still printed to stderr along with a note indicating that the command is
+continuing due to this flag.
+
+### `-o, --output FILE`
+
+Write the response body to `FILE` instead of using the stdout.
+
+### `--resolve HOST:PORT:ADDR`
+
+Use `ADDR` instead of DNS resolution for `HOST:PORT`.
+
+Implementation note: we ignore the `PORT` and replace the `HOST` with
+`ADDR` for every port number. Additionally, when using this flag, the
+DNS lookup fails with "no such host" if the URL host is not `HOST`.
+
+### `-v, --verbose`
+
+Make the operation more talkative.
+
+### `-X, --request METHOD`
+
+Use the given request `METHOD` instead of GET.
+
+## Examples
+
+The following invocation prints the response body
+of the `https://example.com/` website URL:
+
+```
+$ rbmk curl https://example.com/
+```
+
+To also print request and response headers, use `-v`:
+
+```
+$ rbmk curl -v https://example.com/
+```
+
+To save structured logs to `logfile.jsonl` use `--logs`:
+
+```
+$ rbmk curl --logs logfile.jsonl https://example.com/
+```
+
+To save the response body to `output.txt` use `-o`:
+
+```
+$ rbmk curl -o output.txt https://example.com/
+```
+
+To use a previously resolved IP address, use `--resolve`:
+
+```
+$ rbmk curl --resolve example.com:443:93.184.215.14 https://example.com/
+```
+
+## Exit Status
+
+Returns `0` on success. Returns `1` on:
+
+- Usage errors (invalid flags, missing arguments, etc).
+
+- File operation errors (cannot open/close files).
+
+- Measurement failures (unless `--measure` is specified).
+
+## History
+
+The `rbmk curl` command was introduced in RBMK v0.1.0.

--- a/docs/man/rbmk-dig.md
+++ b/docs/man/rbmk-dig.md
@@ -1,0 +1,185 @@
+
+# rbmk dig - DNS Measurements
+
+## Usage
+
+```
+rbmk dig [flags] [@SERVER] NAME [TYPE] [options]
+```
+
+## Description
+
+The `rbmk dig` command emulate a subset of the `dig(1)` command. By default, we
+print output on the standard output emulating what `dig(1)` would print. All queries
+timeout after five seconds by default.
+
+Command line flags start with the `-` character, while query-specific
+options start with the `+` character, just like in `dig(1)`.
+
+Flags MUST come first. The relative order of `@SERVER`, `NAME`, `TYPE`, and
+`+options` is not significant, as long as they come after the flags.
+
+## Arguments
+
+### `@SERVER` (optional)
+
+The optional `@SERVER` argument indicates the name server to use for the
+query. If omitted, we use `8.8.8.8` as the resolver. If `@SERVER` is specified
+multiple times, we emit a warning and use the last one.
+
+### `NAME` (mandatory)
+
+The mandatory `NAME` argument indicates the domain name to query. We do
+not support specifying the `NAME` argument more than once.
+
+### `TYPE` (optional)
+
+The optional `TYPE` argument indicates the query type. If missing, we issue
+a query for the `A` record type. We support these record types:
+
+- `A`: resolves the IPv4 addresses associated with a domain name;
+
+- `AAAA`: resolves the IPv6 addresses associated with a domain name;
+
+- `CNAME`: resolves the canonical name of a domain name;
+
+- `HTTPS`: resolves the ALPNs and possibly IP address associated
+with a domain name;
+
+- `MX`: resolves the mail exchange servers associated with a domain name;
+
+- `NS`: resolves the name servers associated with a domain name.
+
+If you specify `TYPE` multiple times, we emit a warning and use the last one.
+
+## Flags
+
+
+### `-h, --help`
+
+Print this help message.
+
+### `--logs FILE`
+
+Writes structured logs to the given `FILE`. If `FILE` already exists, we
+append to it. If `FILE` does not exist, we create it. If `FILE` is a single
+dash (`-`), we write to the stdout. If you specify `--logs` multiple
+times, we write to the last `FILE` specified.
+
+### `--measure`
+
+Do not exit with `1` if communication with the server fails. Only exit
+with `1` in case of usage errors, or failure to process inputs. You should
+use this flag inside measurement scripts along with `set -e`. Errors are
+still printed to stderr along with a note indicating that the command is
+continuing due to this flag.
+
+### Query Options
+
+### `+https`
+
+Uses DNS-over-HTTPS. The @server argument is the hostname or IP
+address to use. The implied port is `443/tcp`. The implied URL
+path is `/dns-query`. That is, if you use:
+
+```
+@8.8.8.8 +https
+```
+
+We use `https://8.8.8.8/dns-query` to resolve the domain name.
+
+### `+logs`
+
+Prints to the stdout structured logs showing network events
+occurred during the DNS resolution.
+
+### `+noall`
+
+Suppress printing to the stdout.
+
+### `+qr`
+
+Prints the query to the stdout before sending it.
+
+### `+short`
+
+Print a short response rather than the full response.
+
+### `+short=ip`
+
+Like `+short`, but only prints the IP addresses.
+
+### `+tcp`
+
+Uses DNS-over-TCP. The @server argument is the hostname or IP
+address to use. The implied port is `53/tcp`.
+
+### `+tls`
+
+Uses DNS-over-TLS. The @server argument is the hostname or IP
+address to use. The implied port is `853/tcp`.
+
+### `+udp`
+
+Use DNS-over-UDP (default behavior).
+
+### `+udp=wait-duplicates`
+
+Use DNS-over-UDP and wait for the full query timeout to collect
+duplicate responses. Only the first (i.e., non-duplicate) response
+is printed to the stdout. All responses (including duplicates)
+are included in the structured logs. This option is useful
+for detecting DNS-based censorship in China and Iran.
+
+Since v0.4.0, each response (including duplicates) is emitted to the
+stdout as soon as it is received. This behaviour is particularly useful
+when coupling `+short` with writing to an `rbmk pipe`:
+
+```bash
+# Waits for duplicates but immediately print addrs when available
+(rbmk dig +short +udp=wait-duplicates example.com | rbmk pipe write addrs) &
+
+# Print each unique address as soon as it is available
+rbmk pipe read --writers 1 addrs | rbmk ipuniq
+
+# Wait for writer to terminate
+wait
+```
+
+This pattern ensures that we can process each address as soon as it
+is available, even if we are waiting for duplicates.
+
+## Examples
+
+The following invocation resolves `www.example.com` IPv6 address
+(i.e., `AAAA` records) using the `1.1.1.1` name server:
+
+```
+$ rbmk dig @1.1.1.1 www.example.com AAAA
+```
+
+To only print structured logs use `+noall +logs`:
+
+```
+$ rbmk dig www.example.com MX +noall +logs
+```
+
+To append structured logs to a separate file, use the `--logs` flag:
+
+```
+$ rbmk dig --logs LOGS.jsonl www.example.com MX
+```
+
+## Exit Status
+
+Returns `0` on success. Returns `1` on:
+
+- Usage errors (invalid flags, missing arguments, etc).
+
+- File operation errors (cannot open/close files).
+
+- Measurement failures (unless `--measure` is specified).
+
+## History
+
+The `rbmk dig` command was introduced in RBMK v0.1.0.

--- a/docs/man/rbmk-head.md
+++ b/docs/man/rbmk-head.md
@@ -1,0 +1,75 @@
+
+# rbmk head - Print First Lines
+
+## Usage
+
+```
+rbmk head [-n COUNT] [FILE...]
+```
+
+## Description
+
+Print the first `COUNT` lines of each `FILE` to the standard
+output. With no specified `FILE`, or when the `FILE` is `-`, read
+the standard input.
+
+## Flags
+
+### `-h, --help`
+
+Print this help message.
+
+### `-n, --lines COUNT`
+
+Print the first `COUNT` lines instead of the first 10. The
+`COUNT` must be a non-negative integer.
+
+## Examples
+
+Print first 10 lines from stdin:
+
+```
+$ rbmk dig +short=ip example.com | rbmk head
+```
+
+Print first 2 lines from stdin:
+
+```
+$ rbmk dig +short=ip example.com | rbmk head -n 2
+```
+
+Print first 5 lines from multiple files:
+
+```
+$ rbmk head -n 5 file1.txt file2.txt
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## Bugs
+
+When running a command such as:
+
+```
+$ rbmk head
+```
+
+we keep the `stdin` in line-oriented mode, which means that you
+can edit the input before pressing enter. However, this also implies
+that `^C` does not interrupt reading from the `stdin`, because
+the terminal driver is blocked reading until the EOL. The symptom
+of this would be:
+
+```
+$ rbmk head
+^C
+```
+
+where the program does not exit. To exit, insert an explicit
+EOL character (e.g., `^D` on Unix and `^Z` + `Return` on Windows).
+
+## History
+
+The `rbmk head` command was introduced in RBMK v0.11.0.

--- a/docs/man/rbmk-intro.md
+++ b/docs/man/rbmk-intro.md
@@ -1,0 +1,83 @@
+
+# rbmk intro - Quick Start Guide
+
+## Overview
+
+RBMK is designed for composable network measurements. The two core commands
+are `dig` for DNS queries and `curl` for HTTP(S) requests. You can combine
+these to perform step-by-step measurements.
+
+## Basic Examples
+
+### DNS resolution
+
+Get IP address for a domain
+
+```
+$ rbmk dig +short=ip example.com | rbmk head -n1
+93.184.215.14
+```
+
+### HTTP Measurements
+
+Fetch a webpage:
+
+```
+$ rbmk curl https://example.com/
+```
+
+### Using Specific IP address
+
+Fetch webpage using a specific IP address:
+
+```
+$ rbmk curl --resolve example.com:443:93.184.215.14 https://example.com/
+```
+
+Note that `rbmk curl` ignores the port passed to `--resolve` and uses
+the given address for all ports of the given domain.
+
+### Combining Commands
+
+Separate DNS and HTTP measurements:
+
+```bash
+addr=$(rbmk dig +short=ip example.com | rbmk head -n1)
+rbmk curl --resolve example.com:443:$addr https://example.com/
+```
+
+Or, to measure all the available IP addresses:
+
+```bash
+for addr in $(rbmk dig +short=ip example.com); do
+    rbmk curl --resolve example.com:443:$addr https://example.com/
+done
+```
+
+### Collecting Structured Logs
+
+Save measurement logs:
+
+```
+$ rbmk dig --logs dns.jsonl example.com
+$ rbmk curl --logs http.jsonl https://example.com/
+```
+
+Use `--logs -` to emit the logs to the standard output.
+
+## Benefits
+
+This modular approach helps isolate different aspects of network measurements
+and makes it easier to understand where issues occur.
+
+## Next Steps
+
+* Run `rbmk dig --help` for detailed DNS measurement options
+
+* Run `rbmk curl --help` for detailed HTTP measurement options
+
+* Try `rbmk tutorial` for a comprehensive guide
+
+## History
+
+The `rbmk intro` command was introduced in RBMK v0.1.0.

--- a/docs/man/rbmk-ipuniq.md
+++ b/docs/man/rbmk-ipuniq.md
@@ -1,0 +1,172 @@
+
+# rbmk ipuniq - IP Address Processing
+
+## Usage
+
+```
+rbmk ipuniq [flags] [FILE...]
+```
+
+## Description
+
+Read IP addresses from files or stdin and remove duplicates. We expect
+input files, or stdin, to contain one IP address per line. Use `-` as the
+file name to explicitly indicate you want to read from the stdin.
+
+More specifically, `rbmk ipuniq`:
+
+- Reads IPv4 and IPv6 addresses from input files or the stdin
+
+- Normalizes different textual representations
+
+- Removes duplicates
+
+- Optionally, randomly shuffles the resulting addresses
+
+You enable random shuffling with `--random`. When not using `--random`, we
+stream unique addresses as soon as they are read. The streaming functionality
+was implemented in RBMK v0.4.0.
+
+The `-E, --from-endpoints` flag modifies the command behaviour to assume the
+input contains endpoints rather than just IP addresses (see below).
+
+Note that any input line that does not contain a valid IP address or
+endpoint is skipped and a warning is emitted.
+
+## Flags
+
+### `-E, --from-endpoints`
+
+Assume that input already contains endpoints, that is `addr:port`, where
+the `addr` is an IP address, and there is `[` and `]` around IPv6
+addresses. Strip the port, and just retain the IP address for processing
+and emitting according to other `rbmk ipuniq` flags.
+
+### `-f, --fail`
+
+Cause the tool to fail (rather than emitting a warning) if an input
+line does not contain a valid IP address or endpoint (if `-E`).
+
+### `-h, --help`
+
+Print this help message.
+
+### `-p, --port PORT`
+
+Format output as `ADDRESS:PORT` endpoints, adding [] brackets for IPv6
+addresses as needed. This flag can be specified multiple times
+to generate endpoints for multiple ports (e.g., `-p 80 -p 443 -p 22`
+generates HTTP, HTTPS, and SSH endpoints). When no ports are
+specified, we output IP addresses without ports. Each `PORT` must
+be a valid port number (0-65535).
+
+### `--only ipv4|ipv6`
+
+Only output addresses belonging to the specific IP version.
+
+This flag has been introduced in RBMK v0.11.0.
+
+### `-r, --random`
+
+Buffers and randomly shuffles the addresses before output. This
+flag has been introduced in v0.4.0.
+
+## Examples
+
+### Process DNS Resolution Results
+
+Collect and measure unique IP addresses:
+
+```
+$ rbmk dig +short=ip example.com A > dig_A.txt
+
+$ rbmk dig + short=ip example.com AAAA > dig_AAAA.txt
+
+$ for ipAddr in $(rbmk ipuniq dig_A.txt dig_AAAA.txt); do \
+  rbmk curl --resolve "example.com:443:${ipAddr}" https://example.com/ \
+done
+```
+
+Randomize IP addresses read from stdin:
+
+```
+$ rbmk ipuniq --random
+```
+
+Filters stdin and immediately emits unique addresses:
+
+```
+$ rbmk ipuniq
+```
+
+### Generate STUN Endpoints
+
+Create endpoints for STUN measurements:
+
+```
+$ rbmk dig +short=ip stun.l.google.com A > ips.txt
+
+$ rbmk dig +short=ip stun.l.google.com AAAA >> ips.txt
+
+$ rbmk ipuniq --port 19302 stun_A.txt stun_AAAA.txt
+```
+
+### Generate Multiple Endpoints
+
+Create multiple endpoints for each IP addr:
+
+```
+$ rbmk ipuniq --port 80 --port 443 ips.txt
+```
+
+### Filtering a list of endpoints
+
+Filter a list the endpoints and just keep IP addresses:
+
+```
+$ echo -e '10.0.0.1:80\n10.0.0.1:443\n127.0.0.1:111' | rbmk ipuniq -E
+10.0.0.1
+127.0.0.1
+```
+
+Same but using IPv6 endpoints:
+
+```
+$ echo -e '[::1]:80\n[::1]:443' | rbmk ipuniq -E
+::1
+```
+
+### Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## Bugs
+
+When running a command such as:
+
+```
+$ rbmk ipuniq
+```
+
+we keep the `stdin` in line-oriented mode, which means that you
+can edit the input before pressing enter. However, this also implies
+that `^C` does not interrupt reading from the `stdin`, because
+the terminal driver is blocked reading until the EOL. The symptom
+of this would be:
+
+```
+$ rbmk ipuniq
+^C
+```
+
+where the program does not exit. To exit, insert an explicit
+EOL character (e.g., `^D` on Unix and `^Z` + `Return` on Windows).
+
+### History
+
+The `--only` flag was introduced in RBMK v0.11.0.
+
+Before RBMK v0.4.0, this command always randomly shuffled the
+addresses. Afterwards, one must use `--random` explicitly.
+
+This command was introduced in RBMK v0.2.0.

--- a/docs/man/rbmk-markdown.md
+++ b/docs/man/rbmk-markdown.md
@@ -1,0 +1,68 @@
+
+# rbmk markdown - Markdown Rendering
+
+## Usage
+
+```
+rbmk markdown [flags]
+```
+
+## Description
+
+Read markdown from standard input and write formatted output to standard
+output. This command allows you to format markdown text consistently with
+RBMK's own help texts.
+
+Note: when RBMK is compiled with the `rbmk_disable_markdown` build tag,
+this command prints its input unchanged to allow scripts to work even
+when markdown support is disabled.
+
+## Flags
+
+### `-h, --help`
+
+Print this help message.
+
+## Examples
+
+Basic usage:
+
+```
+$ echo "# Hello" | rbmk markdown
+```
+
+Format a help message in a script:
+
+```bash
+rbmk cat << 'EOF' | rbmk markdown
+# My Script
+
+This script does something useful.
+
+## Usage
+
+\`\`\`bash
+./script.sh [flags]
+\`\`\`
+
+## Flags
+
+### --option VALUE
+
+Description of the option.
+EOF
+```
+
+Format a README file:
+
+```
+$ rbmk cat README.md | rbmk markdown
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## History
+
+The `rbmk markdown` command was introduced in RBMK v0.12.0.

--- a/docs/man/rbmk-mkdir.md
+++ b/docs/man/rbmk-mkdir.md
@@ -1,0 +1,43 @@
+
+# rbmk mkdir - Directory Creation
+
+## Usage
+
+```
+rbmk mkdir [-p] DIRECTORY...
+```
+
+Create the `DIRECTORY`(ies), if they do not already exist. We use the
+`0755` file mode to create new directories.
+
+## Flags
+
+### `-h, --help`
+
+Print this help message.
+
+### `-p, --parents`
+
+Create parent directories as needed.
+
+## Examples
+
+Create multiple directories:
+
+```
+$ rbmk mkdir dir1 dir2 dir3
+```
+
+Create nested directories:
+
+```
+$ rbmk mkdir -p a/long/path/of/dirs
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## History
+
+The `rbmk mkdir` command was introduced in RBMK v0.2.0.

--- a/docs/man/rbmk-mv.md
+++ b/docs/man/rbmk-mv.md
@@ -1,0 +1,40 @@
+# rbmk mv - Move Files
+
+## Usage
+
+```
+rbmk mv [-f] SOURCE... DESTINATION
+```
+
+## Description
+
+Move (rename) `SOURCE` to `DESTINATION`. When moving multiple `SOURCE` files,
+the `DESTINATION` must be an existing directory.
+
+## Flags
+
+### `-h, --help`
+
+Print this help message.
+
+## Examples
+
+Move a single file:
+
+```
+$ rbmk mv source.txt destination.txt
+```
+
+Move multiple files to a directory:
+
+```
+$ rbmk mv file1.txt file2.txt target_directory/
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## History
+
+The `rbmk mv` command was introduced in RBMK v0.3.0.

--- a/docs/man/rbmk-nc.md
+++ b/docs/man/rbmk-nc.md
@@ -1,0 +1,161 @@
+# rbmk nc - TCP/TLS Client
+
+## Usage
+
+```
+rbmk nc [flags] HOST PORT
+```
+
+## Description
+
+The `rbmk nc` command emulates a subset of the OpenBSD `nc(1)` command,
+including connecting to remote TCP/TLS endpoints, scanning for open ports,
+sending and receiving data over the network.
+
+The `HOST` may be a domain name, an IPv4 address, or an IPv6 address. When
+using a domain name, we use the system resolver to resolve the name to a
+list of IP addresses and try all of them until one succeeds. For measuring,
+it is recommended to specify an IP address directly.
+
+## Flags
+
+### `--alpn PROTO`
+
+Specify ALPN protocol(s) for TLS connections. Can be specified
+multiple times to support protocol negotiation. For example:
+
+```
+--alpn h2 --alpn http/1.1
+```
+
+Must be used alongside the `--tls` flag.
+
+### `-c, --tls`
+
+Perform a TLS handshake after a successful TCP connection.
+
+### `-h, --help`
+
+Print this help message.
+
+### `--logs FILE`
+
+Writes structured logs to the given `FILE`. If `FILE` already exists, we
+append to it. If `FILE` does not exist, we create it. If `FILE` is a single
+dash (`-`), we write to the stdout. If you specify `--logs` multiple
+times, we write to the last `FILE` specified.
+
+### `--measure`
+
+Do not exit with `1` if communication with the server fails. Only exit
+with `1` in case of usage errors, or failure to process inputs. You should
+use this flag inside measurement scripts along with `set -e`. Errors are
+still printed to stderr along with a note indicating that the command is
+continuing due to this flag.
+
+### `--sni SERVER_NAME`
+
+Specify the server name for the SNI extension in the TLS
+handshake. For example:
+
+```
+--sni www.example.com
+```
+
+Must be used alongside the `--tls` flag.
+
+### `-T, --option OPTION`
+
+Set a specific `OPTION`. Can be specified multiple times to provide
+multiple options. We currently accept the following options:
+
+- `noverify` (added in RBMK v0.11.0): Do not verify the server's
+certificate, which is useful for measuring SNI-based blocking using
+arbitrary TLS endpoints as test helpers. This option only takes
+effect when combined with the `-c, --tls` flag.
+
+The `-T` flag was introduced in RBMK v0.11.0.
+
+### `-v`
+
+Print more verbose output.
+
+### `-w, --timeout TIMEOUT`
+
+Time-out I/O operations (connect, recv, send) after
+a `TIMEOUT` number of seconds.
+
+### `-z, --scan`
+
+Without `--tls`, perform a port scan and report whether the
+remote port is open. With `--tls`, perform a TLS handshake
+and then close the remote connection.
+
+## Examples
+
+Basic TCP connection to HTTP port:
+
+```
+$ rbmk nc example.com 80
+```
+
+TLS connection with HTTP/2 and HTTP/1.1 ALPN:
+
+```
+$ rbmk nc -c --alpn h2 --alpn http/1.1 example.com 443
+```
+
+Check if port is open (scan mode) with a five seconds timeout:
+
+```
+$ rbmk nc -z -w5 example.com 80
+```
+
+Same as above but also perform a TLS handshake:
+
+```
+$ rbmk nc --alpn h2 --alpn http/1.1 -z -c -w5 example.com 443
+```
+
+Checking for SNI based blocking:
+
+```
+$ rbmk nc -zcw5 --alpn h2 --alpn http/1.1 -T noverify \
+    --sni x.com example.com 443
+```
+
+Saving structured logs:
+
+```
+$ rbmk nc --logs conn.jsonl example.com 80
+```
+
+## Exit Status
+
+The nc utility exits with `0` on success and `1` on error.
+
+## Bugs
+
+When running a command such as:
+
+```
+$ rbmk nc example.com 80
+```
+
+we keep the `stdin` in line-oriented mode, which allows to send
+protocol data on a line-by-line basis. However, this also implies
+that `^C` does not interrupt reading from the `stdin`, because
+the terminal driver is blocked reading until the EOL. The symptom
+of this would be:
+
+```
+$ rbmk nc example.com 80
+^C
+```
+
+where the program does not exit. To exit, insert an explicit
+EOL character (e.g., `^D` on Unix and `^Z` + `Return` on Windows).
+
+## History
+
+The `rbmk nc` command was introduced in RBMK v0.6.0.

--- a/docs/man/rbmk-pipe.md
+++ b/docs/man/rbmk-pipe.md
@@ -1,0 +1,99 @@
+
+# rbmk pipe - Named Pipe Operations
+
+## Usage
+
+```
+rbmk pipe COMMAND [args...]
+```
+
+## Description
+
+Create and use named pipes for inter-process communication within
+measurement scripts. Uses Unix domain sockets on both Unix systems
+and modern Windows systems (10.0.17063+).
+
+## Commands
+
+### read
+
+Read from a named pipe. Blocks until writer connects.
+
+### write
+
+Write to a named pipe. Blocks until reader is ready.
+
+## Examples
+
+Read from a pipe:
+
+```
+$ rbmk pipe read mypipe
+```
+
+Write to a pipe:
+
+```
+$ echo "data" | rbmk pipe write mypipe
+```
+
+Typical measurement pattern:
+
+```bash
+#!/bin/bash
+
+# Write addresses as they become available
+( ./rbmk dig +short=ip example.com A | ./rbmk pipe write addresses ) &
+( ./rbmk dig +short=ip example.com AAAA | ./rbmk pipe write addresses ) &
+
+# Use addresses as they become available
+./rbmk pipe read --writers 2 addresses | while read addr; do
+  ./rbmk curl --resolve example.com:443:$addr "https://example.com/"
+done
+```
+
+## Notes
+
+- Pipes are created relative to the current directory
+
+- Pipes are automatically cleaned up when both ends close
+
+- Maximum connection timeout is 1s
+
+## Exit Status
+
+Returns `0` on success. Returns `1` on:
+
+- Usage errors
+
+- Connection timeouts
+
+- I/O errors
+
+## Bugs
+
+Unix domain sockets have a platform-specific maximum path length
+ranging from ~90 to ~108 bytes. If the path length exceeds the
+maximum path length, you will see errors such as:
+
+```
+rbmk pipe read: cannot create pipe: listen unix .../pipe: bind: invalid argument
+```
+
+where `.../pipe` is a path that exceeds the maximum path length.
+
+This limitation could interact with how `rbmk sh` executes `rbmk
+COMMAND` commands (i.e., in the same process) as documented in
+detail by the `rbmk sh --help` output.
+
+To mitigate this issue, use paths relative to the current working
+directory in your scripts and attemp to keep them short. Specifically,
+you can create a unique directory for measuring with a short name,
+using `rbmk timestamp --full` to generate a timestamp-based name with
+nanosecond precision and possibly combining it with `rbmk random` to
+add additional entropy. Then, once the measurement is complete, you
+can move the results to a longer, more logical path name.
+
+## History
+
+The `rbmk pipe` command was introduced in RBMK v0.4.0.

--- a/docs/man/rbmk-random.md
+++ b/docs/man/rbmk-random.md
@@ -1,0 +1,47 @@
+
+# rbmk random - Random Bytes Generation
+
+## Usage
+
+```
+rbmk random [flags]
+```
+
+## Description
+
+Generate random bytes using a cryptographically secure random number
+generator and print them as hexadecimal to stdout.
+
+## Flags
+
+### `-h, --help`
+
+Print this help message.
+
+### `--bytes COUNT`
+
+Number of random bytes to generate. The default is 4 bytes.
+
+## Examples
+
+Generate 4 random bytes (default):
+
+```
+$ rbmk random
+a1b2c3d4
+```
+
+Generate 16 random bytes:
+
+```
+$ rbmk random --bytes 16
+a1b2c3d4e5f6789012345678deadbeef
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## History
+
+The `rbmk random` command was introduced in RBMK v0.12.0.

--- a/docs/man/rbmk-rm.md
+++ b/docs/man/rbmk-rm.md
@@ -1,0 +1,48 @@
+
+# rbmk rm - Remove Files
+
+## Usage
+
+```
+rbmk rm [-rf] file...
+```
+
+## Description
+
+Remove files or directories.
+
+## Flags
+
+### `-f, --force`
+
+Ignore nonexistent-file errors.
+
+### `-h, --help`
+
+Print this help message.
+
+### `-r, --recursive`
+
+Remove directories and their contents recursively.
+
+## Examples
+
+Remove multiple files:
+
+```
+$ rbmk rm file1.txt file2.txt
+```
+
+Remove directory recursively:
+
+```
+$ rbmk rm -rf directory
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## History
+
+The `rbmk rm` command was introduced in RBMK v0.2.0.

--- a/docs/man/rbmk-sh.md
+++ b/docs/man/rbmk-sh.md
@@ -1,0 +1,130 @@
+
+# rbmk sh - Shell Script Execution
+
+## Usage
+
+```
+rbmk sh SCRIPT [ARGUMENTS...]
+```
+
+## Description
+
+Run `SCRIPT` using a POSIX-compliant shell interpreter providing
+to the script the given `ARGUMENTS`, which will be available to
+the script as `$1`, `$2`, etc.
+
+As a special case, if `SCRIPT` is `-h` or `--help`, the command
+prints this help message and exits.
+
+This shell implementation (based on `mvdan.cc/sh/v3`) is consistent
+across operating systems and supports:
+
+- Variables and arithmetic.
+
+- Command substitution `$(...)`.
+
+- Pipes and redirections.
+
+- Loops and conditionals
+
+- Environment variables
+
+## Available Commands
+
+Apart from built-in commands (e.g., `cd`, `test`), the shell will
+only allow running the `rbmk` command, which will behave as when you
+normaly execute `rbmk`, except that `rbmk sh` won't be available.
+
+We do this to restrict the set of commands that `rbmk sh` could run
+and ensure scripts are portable. If you have more complex measurement
+needs, we recommend using GNU bash instead.
+
+## Environment
+
+The `rbmk sh` command inherits the parent environment and includes the
+following environment variables:
+
+### `RBMK_EXE`
+
+Automatically set to `rbmk` to allow scripts written before RBMK
+v0.7.0 to continue running without modification. Since v0.7.0, `rbmk sh`
+cannot execute external commands and is only allowed to run shell
+built-in commands and the `rbmk` command.
+
+## Example
+
+The following example demonstrates how to use `rbmk sh` to run a script that:
+
+1. creates a directory using a timestamp based name
+
+2. uses `rbmk dig` to get the IP addresses of `dns.google`
+
+3. archives the results into a tarball
+
+4. removes the directory
+
+First, let's see the content of the the `script.bash` file:
+
+```sh
+#!/bin/bash
+set -x
+outdir="$(rbmk timestamp --full)-$(rbmk random)"
+rbmk mkdir -p "$outdir"
+rbmk dig +short=ip A "dns.google" > "$outdir/dig1.txt"
+rbmk dig +short=ip AAAA "dns.google" > "$outdir/dig2.txt"
+rbmk tar -czf "results_$outdir.tar.gz" "$outdir"
+rbmk rm -rf "$outdir"
+```
+
+To execute the script using `rbmk sh` run:
+
+```
+$ rbmk sh script.bash
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## Bugs
+
+The `rbmk sh` command executes other `rbmk COMMAND` commands in the same
+process without changing the current working directory. Because `rbmk pipe`
+uses Unix domain sockets, and because such sockets are restricted in the
+maximum path length, `rbmk sh` attempts to minimise path lengths by using
+paths relative to the current working directory.
+
+If `rbmk sh` cannot determine the current working directory when executing
+a command, or it cannot map the subcommand own working directory to the
+current working directory, it emits this warning message:
+
+```
+<date> rmbk sh: cannot create relative-to-cwd dir-path mapper: <error>
+```
+
+and then uses the absolute path instead.
+
+Regardless, using long paths could lead to errors when using `rbmk pipe`
+as documented in `rbmk pipe --help`. See `rbmk pipe --help` for advices
+regarding mitigating this issue in shell scripts.
+
+Note that, because `bash` changes the current working directory, it is
+possible for scripts that work using `bash $script` to instead fail when
+using `rbmk sh $script` precisely because of this issue.
+
+## History
+
+Since RBMK v0.12.0, the `-h, --help` flag is passed by default to the
+`SCRIPT` rather than printing the `rbmk sh` command's help.
+
+Since RBMK v0.10.0, it is possible to pass arguments to the script
+executed by `rbmk sh` using the command line.
+
+Before RBMK v0.7.0, `rbmk sh` used to set the `$RBMK_EXE` environment
+variable to the `rbmk` path, to allow a script to execute `rbmk` commands.
+
+Since v0.7.0. `rbmk` is an internal shell command, `rbmk sh` is not capable
+of executing external commands, and `$RBMK_EXE` is set to `rbmk`, thus
+supporting previously existing scripts without modification.
+
+The `rbmk sh` command was introduced in RBMK v0.2.0.

--- a/docs/man/rbmk-stun.md
+++ b/docs/man/rbmk-stun.md
@@ -1,0 +1,83 @@
+
+# rbmk stun - STUN Measurements
+
+## Usage
+
+```
+rbmk stun [flags] ENDPOINT
+```
+
+## Description
+
+Send a STUN Binding Request to the given `ENDPOINT` and print the reflexive
+transport address (public IP address and port) to standard output.
+
+## Arguments
+
+### `ENDPOINT`
+
+The ENDPOINT argument should be in the form `HOST:PORT`. For example:
+
+- `stun.l.google.com:19302`
+
+- `74.125.250.129:19302`
+
+- `[2001:4860:4864:5:8000::1]:19302`
+
+We recommend using IPv4 and IPv6 addresses explicitly, to collect both
+the externally observable IPv4 and IPv6 addresses.
+
+## Flags
+
+### `-h, --help`
+
+Print this help message.
+
+### `--logs FILE`
+
+Writes structured logs to the given `FILE`. If `FILE` already exists, we
+append to it. If `FILE` does not exist, we create it. If `FILE` is a single
+dash (`-`), we write to the stdout.
+
+### `--max-time DURATION`
+
+Sets the maximum time that the STUN transaction operation is allowed to take
+in seconds (e.g., `--max-time 5`). If this flag is not specified, the
+default max time is 30 seconds.
+
+### `--measure`
+
+Do not exit with `1` if communication with the endpoint fails. Only exit
+with `1` in case of usage errors, or failure to process inputs. You should
+use this flag inside measurement scripts along with `set -e`. Errors are
+still printed to stderr along with a note indicating that the command is
+continuing due to this flag.
+
+## Examples
+
+Basic usage:
+
+```
+$ rbmk stun 74.125.250.129:19302
+192.0.2.1:54321
+```
+
+Save structured logs to a file:
+
+```
+$ rbmk stun --logs stun.jsonl 74.125.250.129:19302
+```
+
+## Exit Status
+
+Returns `0` on success. Returns `1` on:
+
+- Usage errors (invalid flags, missing arguments, etc).
+
+- File operation errors (cannot open/close files).
+
+- Measurement failures (unless `--measure` is specified).
+
+## History
+
+The `rbmk stun` command was introduced in RBMK v0.3.0.

--- a/docs/man/rbmk-tar.md
+++ b/docs/man/rbmk-tar.md
@@ -1,0 +1,48 @@
+
+# rbmk tar - Archive Creation
+
+## Usage
+
+```
+rbmk tar -czf ARCHIVE FILE|DIR...
+```
+
+## Description
+
+Create a tar `ARCHIVE` containing the specified `FILE`s and `DIR`s. We
+only support archiving regular files and directories.
+
+## Flags
+
+### `-c, --create`
+
+Create a new archive.
+
+### `-f, --file NAME`
+
+Set the archive file name and path.
+
+### `-h, --help`
+
+Print this help message.
+
+### `-z, --gzip`
+
+Compress the archive with gzip.
+
+## Examples
+
+Create a compressed archive named `results.tar.gz` containing the
+`measurements` directory contents:
+
+```
+$ rbmk tar -czf results.tar.gz ./measurements
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## History
+
+The `rbmk tar` command was introduced in RBMK v0.2.0.

--- a/docs/man/rbmk-timestamp.md
+++ b/docs/man/rbmk-timestamp.md
@@ -1,0 +1,63 @@
+
+# rbmk timestamp - UTC Timestamp Generation
+
+## Usage
+
+```
+rbmk timestamp
+```
+
+## Description
+
+Print a filesystem-friendly ISO8601 UTC timestamp.
+
+The timestamp format is `YYYYMMDDTHHmmssZ`, for example:
+
+```
+20241201T114117Z
+```
+
+## Flags
+
+### `--full`
+
+Includes nanoseconds into the timestamp, for example:
+
+```
+20241201T114117.123456789Z
+```
+
+This flag was introduced in RBMK v0.12.0.
+
+## Features
+
+This timestamp format:
+
+- Is sortable (chronological order)
+
+- Contains no spaces or special characters
+
+- Is safe for use in filenames
+
+- Uses UTC timezone (indicated by Z suffix)
+
+- Follows the ISO 8601 compact format
+
+## Examples
+
+Create directory with timestamped name:
+
+```
+$ outdir="./Workspace/$(rbmk timestamp --full)"
+$ rbmk mkdir -p "$outdir"
+```
+
+## Exit Status
+
+This command exits with `0` on success and `1` on failure.
+
+## History
+
+The `--full` flag was introduced in RBMK v0.12.0.
+
+The `rbmk timestamp` command was introduced in RBMK v0.2.0.

--- a/docs/man/rbmk-tutorial.md
+++ b/docs/man/rbmk-tutorial.md
@@ -1,0 +1,37 @@
+
+# rbmk tutorial - Documentation and Learning Resources
+
+## Usage
+
+```
+rbmk tutorial [TOPIC]
+```
+
+## Description
+
+Access RBMK tutorials and documentation. Without arguments, shows this
+help. With a topic name, shows the specific tutorial.
+
+## Available Topics
+
+* `basics` - Introduction and fundamental concepts
+* `dns` - DNS measurement patterns
+* `http` - HTTP measurement patterns
+
+## Examples
+
+Show this help:
+
+```
+$ rbmk tutorial
+```
+
+Read the basics tutorial:
+
+```
+$ rbmk tutorial basics
+```
+
+## History
+
+The `rbmk tutorial` command was introduced in RBMK v0.1.0.

--- a/docs/man/rbmk-version.md
+++ b/docs/man/rbmk-version.md
@@ -1,0 +1,26 @@
+
+# rbmk version - Print Version Information
+
+## Usage
+
+```
+rbmk version
+```
+
+## Description
+
+Prints on the stdout version information. We add version information
+when compiling `rbmk` using the `GNUmakefile` makefile.
+
+Possible values for the version information are:
+
+- `dev` if we did not compile using the `GNUMakefile`.
+
+- `vX.Y.Z` if using `GNUMakefile` to build a specific tag.
+
+- `vX.Y.Z-<N>-g<SHA>` if using `GNUMakefile` to build
+a commit not associated with a tag.
+
+## History
+
+The `rbmk version` command was introduced in RBMK v0.5.0.

--- a/docs/man/rbmk.md
+++ b/docs/man/rbmk.md
@@ -1,0 +1,58 @@
+
+# rbmk - Really Basic Measurement Kit
+
+## Usage
+
+```
+rbmk COMMAND [args...]
+```
+
+RBMK (Really Basic Measurement Kit) is a command-line utility
+to facilitate network exploration and measurements.
+
+## Commands
+
+### Core measurement commands
+
+* `curl` - Measures HTTP/HTTPS endpoints with `curl(1)`-like syntax.
+* `dig` - Performs DNS measurements with `dig(1)`-like syntax.
+* `nc` - Measures TCP and TLS endpoints with an OpenBSD `nc(1)`-like syntax.
+* `stun` - Performs STUN binding requests to discover public IP address.
+
+### Unix-like Commands for Scripting
+
+* `cat` - Concatenates files to standard output.
+* `head` - Print first lines of files.
+* `ipuniq` - Shuffle, deduplicate, and format IP addresses.
+* `markdown` - Renders Markdown to console.
+* `mkdir` - Creates directories.
+* `mv` - Moves (renames) files and directories.
+* `pipe` - Creates named pipes for inter-process communication.
+* `random` - Generates random bytes.
+* `rm` - Removes files and directories.
+* `sh` - Runs POSIX shell scripts.
+* `tar` - Creates tar archives.
+* `timestamp` - Prints filesystem-friendly UTC timestamp.
+
+### Help Commands
+
+* `intro` - Shows a brief introduction with usage examples.
+* `tutorial` - Provides comprehensive usage documentation.
+* `version` - Prints the version of the `rbmk` utility to the stdout.
+
+## Getting Started
+
+New to RBMK? Try `rbmk intro` to get started!
+
+Run `rbmk COMMAND --help` for more information about `COMMAND`.
+
+## License
+
+```
+SPDX-License-Identifier: GPL-3.0-or-later
+```
+
+## Reporting Bugs
+
+Please, use the [rbmk-project/issues](https://github.com/rbmk-project/issues)
+repository to report bugs or suggest improvements.

--- a/scripts/copyman.bash
+++ b/scripts/copyman.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# copymash.bash - copies manual pages from ./pkg/cli to ./docs/man
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -euo pipefail
+
+for srcname in $(find ./pkg/cli -type f -name README.md); do
+	destname="./docs/man/rbmk-$(basename "$(dirname "$srcname")").md"
+	cp -v "$srcname" "$destname"
+done
+mv -v "./docs/man/rbmk-rootcmd.md" "./docs/man/rbmk.md"
+
+if [[ $# -gt 0 && $1 == "--fail-if-dirty" ]]; then
+	[[ -z $(git status -s) ]]  # fail if dirty
+fi


### PR DESCRIPTION
This diff adds a script to automatically copy manpages.

We cannot embed outside current directory.

So, the second best is to copy them and ensure using CI that they have not been modified inside the commands without running the script that keeps them up-to-date.